### PR TITLE
remove version number from alpine tags

### DIFF
--- a/dockerhub_doc_config_update.sh
+++ b/dockerhub_doc_config_update.sh
@@ -67,9 +67,8 @@ function generate_official_image_tags() {
 	case $os in
 		"ubuntu") distro="focal" ;;
         "centos") distro="centos7" ;;
-		"alpine") distro="alpine3" ;;
 		"windows") distro=$(echo $dfdir | awk -F '/' '{ print $4 }' ) ;;
-		*) distro=undefined;;
+		*) distro=$os;;
 	esac
 
 	# Official image build tags are as below


### PR DESCRIPTION
Switches the alpine tags to not contain the version number. 

e.g `8-jdk-alpine3` becomes `8-jdk-alpine`