### PR TITLE
add linux/arm64/v8 to alpine image

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -33,7 +33,7 @@ all_jvms="hotspot"
 # Supported arches for each of the os_families
 os_families="linux alpine-linux windows"
 linux_arches="aarch64 armv7l ppc64le s390x x86_64"
-alpine_linux_arches="x86_64"
+alpine_linux_arches="x86_64 aarch64"
 windows_arches="windows-amd windows-nano"
 
 # All supported packages


### PR DESCRIPTION
Add `linux/arm64/v8` support to the alpine builds, which should be supported by the base image:
https://hub.docker.com/layers/alpine/library/alpine/3.15.0/images/sha256-c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060?context=explore