### PR TITLE
Restore curl in Ubuntu and Centos images

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -175,7 +175,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Select the ubuntu OS packages
 print_ubuntu_pkg() {
-	packages="tzdata wget ca-certificates fontconfig locales"
+	packages="tzdata curl wget ca-certificates fontconfig locales"
 	# binutils is needed on JDK13+ for jlink to work https://github.com/docker-library/openjdk/issues/351
 	if [[ $version -ge 13 ]]; then
 		packages+=" binutils"

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -250,7 +250,7 @@ EOI
 
 # Select the CentOS packages.
 print_centos_pkg() {
-	packages="tzdata openssl wget ca-certificates fontconfig gzip tar"
+	packages="tzdata openssl curl wget ca-certificates fontconfig gzip tar"
 	# binutils is needed on JDK13+ for jlink to work https://github.com/docker-library/openjdk/issues/351
 	if [[ $version -ge 13 ]]; then
 		packages+=" binutils"


### PR DESCRIPTION
fixes https://github.com/adoptium/containers/issues/255

Curl was replaced with wget but this inadvertently broke users who were expecting curl to still be in the base image. Considering how small the curl package is I’m putting it back in the base image for now