### PR TITLE
 GH action: add SBOM + scanner for dockerfile and docker images

### DIFF
--- a/.github/trivy.yaml
+++ b/.github/trivy.yaml
@@ -1,0 +1,8 @@
+exit-code: 0
+severity: 'CRITICAL,HIGH'
+ignore-unfixed: true
+format: 'sarif'
+output: 'scan_dockerfile_result.sarif'
+misconfiguration:
+  file-patterns:
+    - "dockerfile:.*Dockerfile.releases.full"

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,31 @@
+name: Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - testci
+
+jobs:
+  scan:
+    name: Scan Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.7.0
+        with:
+          scan-type: 'config'
+          trivy-config: .github/trivy.yaml
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'scan_dockerfile_result.sarif'
+
+      - name: Archive scan results to GitHub
+        uses: actions/upload-artifact@v3
+        with:
+          name: trivyResult
+          path: 'scan_dockerfile_result.sarif'
+          if-no-files-found: error

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,9 +2,6 @@ name: Scan
 
 on:
   pull_request:
-  push:
-    branches:
-      - testci
 
 jobs:
   scan:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - testci
+      - '*'
 
 jobs:
   scan:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,6 +2,9 @@ name: Scan
 
 on:
   pull_request:
+  push:
+    branches:
+      - testci
 
 jobs:
   scan:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -41,6 +41,11 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
+      # - name: Enable WSL on Windows for sbom
+      #   if: runner.os == 'Windows'
+      #   uses: Vampire/setup-wsl@v1
+      #   with:
+      #     distribution: Alpine
       - uses: actions/checkout@v3
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
@@ -61,13 +66,14 @@ jobs:
           format: 'sarif'
           output: 'scan_dockerimage_result.sarif'
           severity: 'CRITICAL,HIGH'
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload Trivy scan results to GitHub Security tab for Linux
         if: steps.scan.conclusion == 'success'
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'scan_dockerimage_result.sarif'
-      - name: Generate SBOM
+      - name: Generate SBOM for Linux
         uses: anchore/sbom-action@v0
+        if: steps.scan.conclusion == 'success'
         with:
           image: '${{ matrix.meta.entries[0].tags[0] }}'
           format: 'cyclonedx-json'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,6 +2,9 @@ name: Test PR
 
 on:
   pull_request:
+  push:
+    branches:
+      - testci
 
 defaults:
   run:
@@ -49,7 +52,9 @@ jobs:
         run: ${{ matrix.runs.test }}
       - name: 'List docker images'
         run: ${{ matrix.runs.images }}
-      - name: Scan Vulnerability
+      - name: Scan Vulnerability on Linux(Windows support, soon)
+        if: runner.os == 'Linux'
+        id: scan
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: '${{ matrix.meta.entries[0].tags[0] }}'
@@ -57,6 +62,7 @@ jobs:
           output: 'scan_dockerimage_result.sarif'
           severity: 'CRITICAL,HIGH'
       - name: Upload Trivy scan results to GitHub Security tab
+        if: steps.scan.conclusion == 'success'
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'scan_dockerimage_result.sarif'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,6 +2,9 @@ name: Test PR
 
 on:
   pull_request:
+  push:
+    branches:
+      - testci
 
 defaults:
   run:
@@ -47,8 +50,25 @@ jobs:
         run: ${{ matrix.runs.build }}
       - name: Test ${{ matrix.name }}
         run: ${{ matrix.runs.test }}
-      - name: '"docker images"'
+      - name: 'List docker images'
         run: ${{ matrix.runs.images }}
+      - name: Scan Vulnerability
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ matrix.meta.entries[0].tags[0] }}'
+          format: 'sarif'
+          output: 'scan_dockerimage_result.sarif'
+          severity: 'CRITICAL,HIGH'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'scan_dockerimage_result.sarif'
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: '${{ matrix.meta.entries[0].tags[0] }}'
+          format: 'cyclonedx-json'
+          artifact-name: "SBOM_${{ matrix.name }}.json"
 
   conclusion:
     name: conclusion
@@ -56,5 +76,5 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: Result
+      - name: Check Test Result
         run: ${{ needs.test.result == 'success' }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,9 +2,6 @@ name: Test PR
 
 on:
   pull_request:
-  push:
-    branches:
-      - testci
 
 defaults:
   run:


### PR DESCRIPTION
 GH action: add SBOM for linux docker images+ scanner for dockerfile 
            - use trivy to scan all Dockerfile.release.full
            - use syft to generate sbom from images we build
            - upload to codeql for trivy scan result from image
            - windows is not working for sbom and trivy yet 
sbom result artifacts: https://github.com/zdtsw/containers/actions/runs/2882299165
scan result: https://github.com/zdtsw/containers/actions/runs/2882299167