### PR TITLE
#261 bump Alpine to 3.16.2

### DIFF
--- a/11/jdk/alpine/Dockerfile.releases.full
+++ b/11/jdk/alpine/Dockerfile.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/11/jre/alpine/Dockerfile.releases.full
+++ b/11/jre/alpine/Dockerfile.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/17/jdk/alpine/Dockerfile.releases.full
+++ b/17/jdk/alpine/Dockerfile.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/17/jre/alpine/Dockerfile.releases.full
+++ b/17/jre/alpine/Dockerfile.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/18/jdk/alpine/Dockerfile.releases.full
+++ b/18/jdk/alpine/Dockerfile.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/18/jre/alpine/Dockerfile.releases.full
+++ b/18/jre/alpine/Dockerfile.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/8/jdk/alpine/Dockerfile.releases.full
+++ b/8/jdk/alpine/Dockerfile.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/8/jre/alpine/Dockerfile.releases.full
+++ b/8/jre/alpine/Dockerfile.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -156,7 +156,7 @@ EOI
 # Print the supported Alpine OS - this is for musl based images
 print_alpine_ver() {
 	cat >> "$1" <<-EOI
-	FROM alpine:3.16
+	FROM alpine:3.16.2
 
 	EOI
 }


### PR DESCRIPTION
the Alpine version 3.16.2 fixes CVE-2022-37434