### PR TITLE
Update GitHub Actions to use new bashbrew action

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,17 +20,15 @@ jobs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: docker-library/bashbrew@v0.1.5
       - id: generate-jobs
         name: Generate Jobs
         run: |
           export GENERATE_STACKBREW_LIBRARY='./dockerhub_doc_config_update.sh /dev/stdout'
           export GITHUB_REPOSITORY="eclipse-temurin"
-          git clone --depth 1 https://github.com/docker-library/bashbrew.git -b master ~/bashbrew
-          strategy="$(~/bashbrew/scripts/github-actions/generate.sh)"
+          strategy="$("$BASHBREW_SCRIPTS/github-actions/generate.sh")"
+          echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
           jq . <<<"$strategy" # sanity check / debugging aid
-          echo "::set-output name=strategy::$strategy"
 
   test:
     needs: generate-jobs


### PR DESCRIPTION
This should fix errors that the old code would've run into thanks to the update to Go 1.18

See https://github.com/docker-library/bashbrew/pull/57 :innocent:

(Pinning this to version v0.1.5 should now also help insulate you from build failures like these in the future!)