### PR TITLE
Fix actions hashes and restrict permissions

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -3,12 +3,15 @@ name: Sanity
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   sanity:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Run Sanity Check Script
         run: " bash sanity.sh"

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -12,9 +12,6 @@ concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 jobs:
   generate-jobs:
     name: Generate Jobs

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -7,10 +7,9 @@ defaults:
   run:
     shell: 'bash -Eeuo pipefail -x {0}'
     
-# Cancel existing runs if user makes another push
 concurrency:
-  group: "${{ github.ref }}"
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   generate-jobs:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -12,6 +12,9 @@ concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   generate-jobs:
     name: Generate Jobs
@@ -19,7 +22,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           fetch-depth: 0
       - id: generate-jobs
@@ -38,7 +41,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -5,19 +5,22 @@ on:
     # Runs every half hour
     - cron: "*/30 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   update_dockerfile:
     if: startsWith(github.repository, 'adoptium/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           persist-credentials: false
 
       - name: Run updater
         run: " bash update_all.sh"
 
-      - uses: gr2m/create-or-update-pull-request-action@v1
+      - uses: gr2m/create-or-update-pull-request-action@dc1726cbf4dd3ce766af4ec29cfb660e0125e8ee # v1
         env:
           GITHUB_TOKEN: ${{ secrets.ADOPTIUM_TEMURIN_BOT_TOKEN }}
         with:


### PR DESCRIPTION
Fix GitHub action dependencies by hashcode and restrict the permissions they run with.
Part of https://github.com/adoptium/adoptium/issues/187