### PR TITLE
Update Alpine to v3.18

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -156,7 +156,7 @@ EOI
 # Print the supported Alpine OS - this is for musl based images
 print_alpine_ver() {
 	cat >> "$1" <<-EOI
-	FROM alpine:3.17
+	FROM alpine:3.18
 
 	EOI
 }


### PR DESCRIPTION
Alpine 3.18.0 has been released on 2023-05-09.
See https://www.alpinelinux.org/releases/.