### PR TITLE
alpine: upgrade to Alpine 3.18

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -156,7 +156,7 @@ EOI
 # Print the supported Alpine OS - this is for musl based images
 print_alpine_ver() {
 	cat >> "$1" <<-EOI
-	FROM alpine:3.17
+	FROM alpine:3.18
 
 	EOI
 }


### PR DESCRIPTION
Upgrade to to latest Alpine Linux major release - 3.18

DCO 1.1 Signed-off-by: Domen Jesenovec