### PR TITLE
Fix: correct path of src.zip to be removed from image 

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Run Sanity Check Script
         run: " bash sanity.sh"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Run Sanity Check Script
         run: " bash sanity.sh"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
       - name: Run Sanity Check Script
         run: " bash sanity.sh"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
 
       - name: Run Sanity Check Script
         run: " bash sanity.sh"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
 
       - name: Run Sanity Check Script
         run: " bash sanity.sh"

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -19,7 +19,7 @@ jobs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: docker-library/bashbrew@026ccf128d6c4fcc5c92e4db218095faa2453cee # v0.1.7
+      - uses: docker-library/bashbrew@7e160dca3123caecf32c33ba31821dd2aa3716cd # v0.1.8
       - id: generate-jobs
         name: Generate Jobs
         run: |

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - uses: docker-library/bashbrew@7e160dca3123caecf32c33ba31821dd2aa3716cd # v0.1.8
       - id: generate-jobs
         name: Generate Jobs
@@ -34,7 +34,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: docker-library/bashbrew@026ccf128d6c4fcc5c92e4db218095faa2453cee # v0.1.7
       - id: generate-jobs
         name: Generate Jobs
@@ -34,7 +34,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - uses: docker-library/bashbrew@7e160dca3123caecf32c33ba31821dd2aa3716cd # v0.1.8
       - id: generate-jobs
         name: Generate Jobs
@@ -34,7 +34,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: docker-library/bashbrew@7e160dca3123caecf32c33ba31821dd2aa3716cd # v0.1.8
       - id: generate-jobs
         name: Generate Jobs
@@ -34,7 +34,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
       - uses: docker-library/bashbrew@7e160dca3123caecf32c33ba31821dd2aa3716cd # v0.1.8
       - id: generate-jobs
         name: Generate Jobs
@@ -34,7 +34,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     if: startsWith(github.repository, 'adoptium/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     if: startsWith(github.repository, 'adoptium/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     if: startsWith(github.repository, 'adoptium/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     if: startsWith(github.repository, 'adoptium/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     if: startsWith(github.repository, 'adoptium/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           persist-credentials: false
 

--- a/11/jdk/alpine/Dockerfile.releases.full
+++ b/11/jdk/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/11/jdk/centos/Dockerfile.releases.full
+++ b/11/jdk/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/11/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/11/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -63,7 +63,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/11/jdk/ubuntu/focal/Dockerfile.releases.full
+++ b/11/jdk/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/11/jdk/ubuntu/jammy/Dockerfile.releases.full
+++ b/11/jdk/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/11/jre/alpine/Dockerfile.releases.full
+++ b/11/jre/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/11/jre/centos/Dockerfile.releases.full
+++ b/11/jre/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/11/jre/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/11/jre/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -63,7 +63,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/11/jre/ubuntu/focal/Dockerfile.releases.full
+++ b/11/jre/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/11/jre/ubuntu/jammy/Dockerfile.releases.full
+++ b/11/jre/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/17/jdk/alpine/Dockerfile.releases.full
+++ b/17/jdk/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/17/jdk/centos/Dockerfile.releases.full
+++ b/17/jdk/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/17/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/17/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -63,7 +63,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/17/jdk/ubuntu/focal/Dockerfile.releases.full
+++ b/17/jdk/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/17/jdk/ubuntu/jammy/Dockerfile.releases.full
+++ b/17/jdk/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/17/jre/alpine/Dockerfile.releases.full
+++ b/17/jre/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/17/jre/centos/Dockerfile.releases.full
+++ b/17/jre/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/17/jre/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/17/jre/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -63,7 +63,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/17/jre/ubuntu/focal/Dockerfile.releases.full
+++ b/17/jre/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/17/jre/ubuntu/jammy/Dockerfile.releases.full
+++ b/17/jre/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/18/jdk/alpine/Dockerfile.releases.full
+++ b/18/jdk/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/18/jdk/centos/Dockerfile.releases.full
+++ b/18/jdk/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/18/jdk/ubuntu/focal/Dockerfile.releases.full
+++ b/18/jdk/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/18/jdk/ubuntu/jammy/Dockerfile.releases.full
+++ b/18/jdk/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/18/jre/alpine/Dockerfile.releases.full
+++ b/18/jre/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/18/jre/centos/Dockerfile.releases.full
+++ b/18/jre/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/18/jre/ubuntu/focal/Dockerfile.releases.full
+++ b/18/jre/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/18/jre/ubuntu/jammy/Dockerfile.releases.full
+++ b/18/jre/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/19/jdk/alpine/Dockerfile.releases.full
+++ b/19/jdk/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/19/jdk/centos/Dockerfile.releases.full
+++ b/19/jdk/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/19/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/19/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -63,7 +63,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/19/jdk/ubuntu/focal/Dockerfile.releases.full
+++ b/19/jdk/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/19/jdk/ubuntu/jammy/Dockerfile.releases.full
+++ b/19/jdk/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/19/jre/alpine/Dockerfile.releases.full
+++ b/19/jre/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/19/jre/centos/Dockerfile.releases.full
+++ b/19/jre/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/19/jre/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/19/jre/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -63,7 +63,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/19/jre/ubuntu/focal/Dockerfile.releases.full
+++ b/19/jre/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/19/jre/ubuntu/jammy/Dockerfile.releases.full
+++ b/19/jre/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/20/jdk/alpine/Dockerfile.releases.full
+++ b/20/jdk/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/20/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/20/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -55,7 +55,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/20/jdk/ubuntu/jammy/Dockerfile.releases.full
+++ b/20/jdk/ubuntu/jammy/Dockerfile.releases.full
@@ -58,7 +58,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/20/jre/alpine/Dockerfile.releases.full
+++ b/20/jre/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/20/jre/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/20/jre/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -55,7 +55,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \

--- a/20/jre/ubuntu/jammy/Dockerfile.releases.full
+++ b/20/jre/ubuntu/jammy/Dockerfile.releases.full
@@ -58,7 +58,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/8/jdk/alpine/Dockerfile.releases.full
+++ b/8/jdk/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && echo javac -version && javac -version \

--- a/8/jdk/centos/Dockerfile.releases.full
+++ b/8/jdk/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && echo javac -version && javac -version \

--- a/8/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/8/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && echo javac -version && javac -version \

--- a/8/jdk/ubuntu/focal/Dockerfile.releases.full
+++ b/8/jdk/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/8/jdk/ubuntu/jammy/Dockerfile.releases.full
+++ b/8/jdk/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/8/jre/alpine/Dockerfile.releases.full
+++ b/8/jre/alpine/Dockerfile.releases.full
@@ -52,7 +52,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && echo java -version && java -version \

--- a/8/jre/centos/Dockerfile.releases.full
+++ b/8/jre/centos/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && echo java -version && java -version \

--- a/8/jre/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/8/jre/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -59,7 +59,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
 
 RUN echo Verifying install ... \
     && echo java -version && java -version \

--- a/8/jre/ubuntu/focal/Dockerfile.releases.full
+++ b/8/jre/ubuntu/focal/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/8/jre/ubuntu/jammy/Dockerfile.releases.full
+++ b/8/jre/ubuntu/jammy/Dockerfile.releases.full
@@ -70,7 +70,7 @@ RUN set -eux; \
 	      --strip-components 1 \
 	      --no-same-owner \
 	  ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -436,14 +436,14 @@ EOI
 
 print_java_install_post() {
 	cat >> "$1" <<-EOI
-    rm -f /tmp/openjdk.tar.gz \${JAVA_HOME}/src.zip;
+    rm -f /tmp/openjdk.tar.gz \${JAVA_HOME}/lib/src.zip;
 EOI
 }
 
 print_ubuntu_java_install_post() {
 	above_8="^(9|[1-9][0-9]+)$"
 	cat >> "$1" <<-EOI
-    rm -f /tmp/openjdk.tar.gz \${JAVA_HOME}/src.zip; \\
+    rm -f /tmp/openjdk.tar.gz \${JAVA_HOME}/lib/src.zip; \\
 # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "\$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \\
 EOI


### PR DESCRIPTION
Ref: https://github.com/adoptium/containers/issues/268

As @maffe pointed out, the path is incorrect.
I've verified in both [old JDK17 on x64](https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.5_8.tar.gz) release and [new/latest JDK17 on alpine](https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_x64_alpine-linux_hotspot_17.0.7_7.tar.gz) release tarballs, both have src.zip under "lib" dir.
