### PR TITLE
Increase JVM memory percentage

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -782,7 +782,7 @@ print_java_options() {
 
 	if [ -n "${JOPTS}" ]; then
 	cat >> "$1" <<-EOI
-ENV JAVA_TOOL_OPTIONS="${JOPTS}"
+ENV JAVA_TOOL_OPTIONS="${JOPTS} -XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 EOI
 	fi
 }


### PR DESCRIPTION
The JVM by default uses only 25% of the system memory. In a container environment we should have this larger so that the system doesn't necessarily go through memory thrash despite most of the allocated memory still being available.