### PR TITLE
Fix Gradle v7.5+ not working with UBI based Docker images

### DIFF
--- a/11/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/11/jdk/ubi/ubi9-minimal/Dockerfile
@@ -39,6 +39,9 @@ RUN set -eux; \
         ca-certificates \
         fontconfig \
         glibc-langpack-en \
+        # Required for Gradle v7.5+ which requires the command xargs (included in findutils) \
+        # https://github.com/adoptium/containers/issues/462
+        findutils \
     ; \
     microdnf clean all
 

--- a/11/jre/ubi/ubi9-minimal/Dockerfile
+++ b/11/jre/ubi/ubi9-minimal/Dockerfile
@@ -39,6 +39,9 @@ RUN set -eux; \
         ca-certificates \
         fontconfig \
         glibc-langpack-en \
+        # Required for Gradle v7.5+ which requires the command xargs (included in findutils) \
+        # https://github.com/adoptium/containers/issues/462
+        findutils \
     ; \
     microdnf clean all
 

--- a/17/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/17/jdk/ubi/ubi9-minimal/Dockerfile
@@ -39,6 +39,9 @@ RUN set -eux; \
         ca-certificates \
         fontconfig \
         glibc-langpack-en \
+        # Required for Gradle v7.5+ which requires the command xargs (included in findutils) \
+        # https://github.com/adoptium/containers/issues/462
+        findutils \
     ; \
     microdnf clean all
 

--- a/17/jre/ubi/ubi9-minimal/Dockerfile
+++ b/17/jre/ubi/ubi9-minimal/Dockerfile
@@ -39,6 +39,9 @@ RUN set -eux; \
         ca-certificates \
         fontconfig \
         glibc-langpack-en \
+        # Required for Gradle v7.5+ which requires the command xargs (included in findutils) \
+        # https://github.com/adoptium/containers/issues/462
+        findutils \
     ; \
     microdnf clean all
 

--- a/19/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/19/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -25,7 +25,7 @@ ENV PATH $JAVA_HOME/bin:$PATH
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN microdnf install -y binutils tzdata openssl wget ca-certificates fontconfig glibc-langpack-en gzip tar \
+RUN microdnf install -y binutils tzdata openssl wget ca-certificates fontconfig glibc-langpack-en gzip tar findutils \
     && microdnf clean all
 
 ENV JAVA_VERSION jdk-19.0.2+7

--- a/19/jre/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/19/jre/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -25,7 +25,7 @@ ENV PATH $JAVA_HOME/bin:$PATH
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN microdnf install -y binutils tzdata openssl wget ca-certificates fontconfig glibc-langpack-en gzip tar \
+RUN microdnf install -y binutils tzdata openssl wget ca-certificates fontconfig glibc-langpack-en gzip tar findutils \
     && microdnf clean all
 
 ENV JAVA_VERSION jdk-19.0.2+7

--- a/20/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/20/jdk/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -25,7 +25,7 @@ ENV PATH $JAVA_HOME/bin:$PATH
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN microdnf install -y binutils tzdata openssl wget ca-certificates fontconfig glibc-langpack-en gzip tar \
+RUN microdnf install -y binutils tzdata openssl wget ca-certificates fontconfig glibc-langpack-en gzip tar findutils \
     && microdnf clean all
 
 ENV JAVA_VERSION jdk-20.0.2+9

--- a/20/jre/ubi/ubi9-minimal/Dockerfile.releases.full
+++ b/20/jre/ubi/ubi9-minimal/Dockerfile.releases.full
@@ -25,7 +25,7 @@ ENV PATH $JAVA_HOME/bin:$PATH
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN microdnf install -y binutils tzdata openssl wget ca-certificates fontconfig glibc-langpack-en gzip tar \
+RUN microdnf install -y binutils tzdata openssl wget ca-certificates fontconfig glibc-langpack-en gzip tar findutils \
     && microdnf clean all
 
 ENV JAVA_VERSION jdk-20.0.2+9

--- a/21/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/21/jdk/ubi/ubi9-minimal/Dockerfile
@@ -39,6 +39,9 @@ RUN set -eux; \
         ca-certificates \
         fontconfig \
         glibc-langpack-en \
+        # Required for Gradle v7.5+ which requires the command xargs (included in findutils) \
+        # https://github.com/adoptium/containers/issues/462
+        findutils \
     ; \
     microdnf clean all
 

--- a/21/jre/ubi/ubi9-minimal/Dockerfile
+++ b/21/jre/ubi/ubi9-minimal/Dockerfile
@@ -39,6 +39,9 @@ RUN set -eux; \
         ca-certificates \
         fontconfig \
         glibc-langpack-en \
+        # Required for Gradle v7.5+ which requires the command xargs (included in findutils) \
+        # https://github.com/adoptium/containers/issues/462
+        findutils \
     ; \
     microdnf clean all
 

--- a/8/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/8/jdk/ubi/ubi9-minimal/Dockerfile
@@ -39,6 +39,9 @@ RUN set -eux; \
         ca-certificates \
         fontconfig \
         glibc-langpack-en \
+        # Required for Gradle v7.5+ which requires the command xargs (included in findutils) \
+        # https://github.com/adoptium/containers/issues/462
+        findutils \
     ; \
     microdnf clean all
 

--- a/8/jre/ubi/ubi9-minimal/Dockerfile
+++ b/8/jre/ubi/ubi9-minimal/Dockerfile
@@ -39,6 +39,9 @@ RUN set -eux; \
         ca-certificates \
         fontconfig \
         glibc-langpack-en \
+        # Required for Gradle v7.5+ which requires the command xargs (included in findutils) \
+        # https://github.com/adoptium/containers/issues/462
+        findutils \
     ; \
     microdnf clean all
 

--- a/docker_templates/ubi9-minimal.Dockerfile.j2
+++ b/docker_templates/ubi9-minimal.Dockerfile.j2
@@ -18,6 +18,9 @@ RUN set -eux; \
         ca-certificates \
         fontconfig \
         glibc-langpack-en \
+        # Required for Gradle v7.5+ which requires the command xargs (included in findutils) \
+        # https://github.com/adoptium/containers/issues/462
+        findutils \
     ; \
     microdnf clean all
 


### PR DESCRIPTION
Fixes #462 Gradle v7.5+ not working with UBI based Docker images.