### PR TITLE
Correct docker templates entrypoint symlink

### DIFF
--- a/config/hotspot.yml
+++ b/config/hotspot.yml
@@ -18,11 +18,6 @@ supported_distributions:
 
 configurations:
   linux:
-  - directory: ubuntu/lunar
-    image: ubuntu:23.04
-    architectures: [aarch64, arm, ppc64le, s390x, x64]
-    os: ubuntu
-
   - directory: ubuntu/jammy
     image: ubuntu:22.04
     architectures: [aarch64, arm, ppc64le, s390x, x64]

--- a/config/hotspot.yml
+++ b/config/hotspot.yml
@@ -18,6 +18,11 @@ supported_distributions:
 
 configurations:
   linux:
+  - directory: ubuntu/lunar
+    image: ubuntu:23.04
+    architectures: [aarch64, arm, ppc64le, s390x, x64]
+    os: ubuntu
+
   - directory: ubuntu/jammy
     image: ubuntu:22.04
     architectures: [aarch64, arm, ppc64le, s390x, x64]

--- a/docker_templates/scripts/entrypoint.ubuntu.sh
+++ b/docker_templates/scripts/entrypoint.ubuntu.sh
@@ -1,1 +1,1 @@
-entrypoint.alpine.sh
+entrypoint.alpine-linux.sh


### PR DESCRIPTION
Solve error in sanity.sh

The symlink docker_templates/scripts/entrypoint.ubuntu.sh was targetting an non existant docker_templates/scripts/entrypoint.alpine.sh

I correct it to docker_templates/scripts/entrypoint.alpine-linux.sh