### PR TITLE
ci: support orgs with default: read permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,10 @@
 name: Dependabot auto-merge
 on: pull_request_target
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   dependabot:
     uses: adoptium/.github/.github/workflows/dependabot-auto-merge.yml@main


### PR DESCRIPTION
Without this change, [forks that default to readonly permissions fail](
https://github.com/check-spelling-sandbox/containers/actions/runs/7620879148) ([By default, when you create a new organization, `GITHUB_TOKEN` only has read access for the `contents` and `packages` scopes.](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#configuring-the-default-github_token-permissions)) with:

> [Invalid workflow file: .github/workflows/dependabot-auto-merge.yml#L5](https://github.com/check-spelling-sandbox/containers/actions/runs/7620879148/workflow)
The workflow is not valid. .github/workflows/dependabot-auto-merge.yml (Line: 5, Col: 3): Error calling workflow 'adoptium/.github/.github/workflows/dependabot-auto-merge.yml@main'. The workflow is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.

With this change, the [workflow is deemed valid (and could thus do whatever it does)](https://github.com/check-spelling-sandbox/containers/actions/runs/7621296795).