### PR TITLE
Only add binutils for JDK images

### DIFF
--- a/17/jre/alpine/Dockerfile
+++ b/17/jre/alpine/Dockerfile
@@ -36,9 +36,6 @@ RUN set -eux; \
         ca-certificates p11-kit-trust \
         # locales ensures proper character encoding and locale-specific behaviors using en_US.UTF-8
         musl-locales musl-locales-lang \
-        # jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
-        # Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
-        binutils \
         tzdata \
     ; \
     rm -rf /var/cache/apk/*

--- a/17/jre/centos/Dockerfile
+++ b/17/jre/centos/Dockerfile
@@ -29,9 +29,6 @@ RUN set -eux; \
     yum install -y \
         gzip \
         tar \
-        # jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
-        # Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
-        binutils \
         # curl required for historical reasons, see https://github.com/adoptium/containers/issues/255
         curl \
         wget \

--- a/17/jre/ubuntu/focal/Dockerfile
+++ b/17/jre/ubuntu/focal/Dockerfile
@@ -38,9 +38,6 @@ RUN set -eux; \
         # utilities for keeping Ubuntu and OpenJDK CA certificates in sync
         # https://github.com/adoptium/containers/issues/293
         ca-certificates p11-kit \
-        # jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
-        # Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
-        binutils \
         tzdata \
         # locales ensures proper character encoding and locale-specific behaviors using en_US.UTF-8
         locales \

--- a/17/jre/ubuntu/jammy/Dockerfile
+++ b/17/jre/ubuntu/jammy/Dockerfile
@@ -38,9 +38,6 @@ RUN set -eux; \
         # utilities for keeping Ubuntu and OpenJDK CA certificates in sync
         # https://github.com/adoptium/containers/issues/293
         ca-certificates p11-kit \
-        # jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
-        # Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
-        binutils \
         tzdata \
         # locales ensures proper character encoding and locale-specific behaviors using en_US.UTF-8
         locales \

--- a/21/jre/alpine/Dockerfile
+++ b/21/jre/alpine/Dockerfile
@@ -36,9 +36,6 @@ RUN set -eux; \
         ca-certificates p11-kit-trust \
         # locales ensures proper character encoding and locale-specific behaviors using en_US.UTF-8
         musl-locales musl-locales-lang \
-        # jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
-        # Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
-        binutils \
         tzdata \
     ; \
     rm -rf /var/cache/apk/*

--- a/21/jre/ubuntu/jammy/Dockerfile
+++ b/21/jre/ubuntu/jammy/Dockerfile
@@ -38,9 +38,6 @@ RUN set -eux; \
         # utilities for keeping Ubuntu and OpenJDK CA certificates in sync
         # https://github.com/adoptium/containers/issues/293
         ca-certificates p11-kit \
-        # jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
-        # Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
-        binutils \
         tzdata \
         # locales ensures proper character encoding and locale-specific behaviors using en_US.UTF-8
         locales \

--- a/docker_templates/partials/binutils.j2
+++ b/docker_templates/partials/binutils.j2
@@ -1,4 +1,4 @@
-        {% if version|int >= 13 -%}
+        {% if image_type == "jdk" and version|int >= 13 -%}
         # jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351
         # Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
         binutils \


### PR DESCRIPTION
binutils is needed for jlink to be able to use objcopy, but jlink doesn't exist in JRE builds.