### PR TITLE
Add minideb linux

### DIFF
--- a/config/hotspot.yml
+++ b/config/hotspot.yml
@@ -13,7 +13,7 @@
 #
 
 supported_distributions:
-  OS: [alpine, focal, jammy, centos, ubi9-minimal, windowsservercore-1809, nanoserver-1809, windowsservercore-ltsc2022, nanoserver-ltsc2022]
+  OS: [alpine, focal, jammy, centos, ubi9-minimal, minideb, windowsservercore-1809, nanoserver-1809, windowsservercore-ltsc2022, nanoserver-ltsc2022]
   Versions: [8, 11, 17, 21]
 
 configurations:
@@ -39,6 +39,11 @@ configurations:
     architectures: [aarch64, ppc64le, s390x, x64]
     image: redhat/ubi9-minimal
     os: ubi9-minimal
+
+  - directory: minideb/bullseye
+    architectures: [aarch64, x64]
+    image: bitnami/minideb:bullseye
+    os: minideb
     
   alpine-linux:
   - directory: alpine

--- a/docker_templates/minideb.Dockerfile.j2
+++ b/docker_templates/minideb.Dockerfile.j2
@@ -1,0 +1,47 @@
+{% include 'partials/license.j2' %}
+
+FROM {{ base_image }}
+
+{% include 'partials/nix-env.j2' %}
+
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        {% if version|int < 22 -%}
+        # curl required for historical reasons, see https://github.com/adoptium/containers/issues/255
+        curl \
+        {% endif -%}
+        wget \
+        # java.lang.UnsatisfiedLinkError: libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
+        # java.lang.NoClassDefFoundError: Could not initialize class sun.awt.X11FontManager
+        # https://github.com/docker-library/openjdk/pull/235#issuecomment-424466077
+        fontconfig \
+        # utilities for keeping Ubuntu and OpenJDK CA certificates in sync
+        # https://github.com/adoptium/containers/issues/293
+        ca-certificates p11-kit \
+{% include 'partials/binutils.j2' -%}
+        tzdata \
+        # locales ensures proper character encoding and locale-specific behaviors using en_US.UTF-8
+        locales \
+    ; \
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen; \
+    locale-gen en_US.UTF-8; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_VERSION {{ java_version }}
+
+{% include 'partials/multi-arch-install.j2' %} \
+    # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
+    find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
+    {% if version|int >= 11 -%}
+    ldconfig; \
+    # https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
+    # https://openjdk.java.net/jeps/341
+    java -Xshare:dump;
+{% else -%}
+    ldconfig;
+{% endif %}
+{% include 'partials/version-check.j2' %}
+COPY entrypoint.sh /__cacert_entrypoint.sh
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
+{% include 'partials/jshell.j2' %}

--- a/docker_templates/scripts/entrypoint.minideb.sh
+++ b/docker_templates/scripts/entrypoint.minideb.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Sheband needs to be `bash`, see https://github.com/adoptium/containers/issues/415 for details
+
+set -e
+
+# Opt-in is only activated if the environment variable is set
+if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
+
+    # Copy certificates from /certificates to the system truststore, but only if the directory exists and is not empty.
+    # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
+    # system location, for whatever reason.
+    if [ -d /certificates ] && [ "$(ls -A /certificates)" ]; then
+        cp -a /certificates/* /usr/local/share/ca-certificates/
+    fi
+
+    CACERT=$JAVA_HOME/lib/security/cacerts
+
+    # JDK8 puts its JRE in a subdirectory
+    if [ -f "$JAVA_HOME/jre/lib/security/cacerts" ]; then
+        CACERT=$JAVA_HOME/jre/lib/security/cacerts
+    fi
+
+    # OpenJDK images used to create a hook for `update-ca-certificates`. Since we are using an entrypoint anyway, we
+    # might as well just generate the truststore and skip the hooks.
+    update-ca-certificates
+
+    trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose=server-auth "$CACERT"
+fi
+
+exec "$@"

--- a/dockerhub_doc_config_update.sh
+++ b/dockerhub_doc_config_update.sh
@@ -74,6 +74,7 @@ function generate_official_image_tags() {
 		"ubi") distro=$(echo $dfdir | awk -F '/' '{ print $4 }' ) ;;
         "centos") distro="centos7" ;;
 		"windows") distro=$(echo $dfdir | awk -F '/' '{ print $4 }' ) ;;
+		"minideb") distro=$(echo $dfdir | awk -F '/' '{ print $4 }' ) ;;
 		*) distro=$os;;
 	esac
 


### PR DESCRIPTION
Create eclipse-temurin image base on minideb linux which has 24-hour update cycle so has less security vulnerabilities