### PR TITLE
bump PR generator action

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run updater
         run: "python3 generate_dockerfiles.py"
 
-      - uses: gr2m/create-or-update-pull-request-action@dc1726cbf4dd3ce766af4ec29cfb660e0125e8ee # v1
+      - uses: gr2m/create-or-update-pull-request-action@73b5860c078571041abd2e438b8377a24dbc2465 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.ADOPTIUM_TEMURIN_BOT_TOKEN }}
         with:


### PR DESCRIPTION
fixes the following warnings:


update_dockerfileNode.js 16 actions are deprecated. Please update the following actions to use Node.js 20: gr2m/create-or-update-pull-request-action@dc1726cbf4dd3ce766af4ec29cfb660e0125e8ee. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.Show more
--
update_dockerfileThe `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

[update_dockerfile](https://github.com/adoptium/containers/actions/runs/8438259881/job/23110015531)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: gr2m/create-or-update-pull-request-action@dc1726cbf4dd3ce766af4ec29cfb660e0125e8ee. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
[update_dockerfile](https://github.com/adoptium/containers/actions/runs/8438259881/job/23110015531#step:6:21)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/