### PR TITLE
Add request caching to Dockerfile generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ official-eclipse-temurin
 library/
 .vscode/
 __pycache__/
+/adoptium_cache.sqlite

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -13,9 +13,12 @@
 
 import os
 
+import requests_cache
 import requests
 import yaml
 from jinja2 import Environment, FileSystemLoader
+
+requests_cache.install_cache("adoptium_cache", expire_after=3600)
 
 # Setup the Jinja2 environment
 env = Environment(loader=FileSystemLoader("docker_templates"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Jinja2==3.1.3
 PyYAML==6.0.1
 Requests==2.31.0
+requests-cache==1.2.0


### PR DESCRIPTION
When developing parts of the Dockerfile generation pipeline, and thus regenerating Dockerfiles over and over, many unnecessary HTTP requests are being made to https://api.adoptium.net, since the data is mostly unchanged. Adding a request cache with an expiration time of an hour allows this regeneration to run in under a second in most case, while not compromising on the correctness.