### PR TITLE
provide way to skip cache when updater is manually run

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Set DISABLE_CACHE if triggered by workflow_dispatch
+        run: echo "DISABLE_CACHE=true" >> $GITHUB_ENV
+        if: github.event_name == 'workflow_dispatch'
+
       - name: Install dependencies
         run: "pip3 install -r requirements.txt"
 

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -13,12 +13,15 @@
 
 import os
 
-import requests_cache
 import requests
+import requests_cache
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
-requests_cache.install_cache("adoptium_cache", expire_after=3600)
+# Check if arg is set to disable cache
+if not os.environ.get("DISABLE_CACHE"):
+    # Cache requests for 1 hour
+    requests_cache.install_cache("adoptium_cache", expire_after=3600)
 
 # Setup the Jinja2 environment
 env = Environment(loader=FileSystemLoader("docker_templates"))


### PR DESCRIPTION
CC @tellison, this might provide a solution to your concerns raised in https://github.com/adoptium/containers/pull/536#pullrequestreview-2014397229