### PR TITLE
Bump Alpine version to 3.20 to fix the Busybox Vulnerabilities in 3.19

### DIFF
--- a/11/jdk/alpine/Dockerfile
+++ b/11/jdk/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/11/jre/alpine/Dockerfile
+++ b/11/jre/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/17/jdk/alpine/Dockerfile
+++ b/17/jdk/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/17/jre/alpine/Dockerfile
+++ b/17/jre/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/21/jdk/alpine/Dockerfile
+++ b/21/jdk/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/21/jre/alpine/Dockerfile
+++ b/21/jre/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/22/jdk/alpine/Dockerfile
+++ b/22/jdk/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/22/jre/alpine/Dockerfile
+++ b/22/jre/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/8/jre/alpine/Dockerfile
+++ b/8/jre/alpine/Dockerfile
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/config/hotspot.yml
+++ b/config/hotspot.yml
@@ -43,7 +43,7 @@ configurations:
   alpine-linux:
   - directory: alpine
     architectures: [aarch64, x64]
-    image: alpine:3.19
+    image: alpine:3.20
     os: alpine-linux
   
   windows:


### PR DESCRIPTION
Bumping Alpine version to 3.20 from 3.19, as 3.19 has 4 Medium Vulnerabilties in busybox
CVE-2023-42363⁠,CVE-2023-42364,CVE-2023-42365⁠,CVE-2023-42366⁠