### PR TITLE
use jinja templating to remove distro specific cases in entrypoint.sh

### DIFF
--- a/11/jdk/alpine/Dockerfile
+++ b/11/jdk/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/alpine/entrypoint.sh
+++ b/11/jdk/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jdk/alpine/entrypoint.sh
+++ b/11/jdk/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/11/jdk/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/11/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/11/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/ubuntu/focal/Dockerfile
+++ b/11/jdk/ubuntu/focal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -100,6 +100,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/11/jdk/ubuntu/focal/entrypoint.sh
+++ b/11/jdk/ubuntu/focal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jdk/ubuntu/focal/entrypoint.sh
+++ b/11/jdk/ubuntu/focal/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/ubuntu/jammy/Dockerfile
+++ b/11/jdk/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -100,6 +100,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/11/jdk/ubuntu/jammy/entrypoint.sh
+++ b/11/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jdk/ubuntu/jammy/entrypoint.sh
+++ b/11/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/ubuntu/noble/Dockerfile
+++ b/11/jdk/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -100,6 +100,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/11/jdk/ubuntu/noble/entrypoint.sh
+++ b/11/jdk/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jdk/ubuntu/noble/entrypoint.sh
+++ b/11/jdk/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/windows/nanoserver-1809/Dockerfile
+++ b/11/jdk/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/11/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/11/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/alpine/Dockerfile
+++ b/11/jre/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/alpine/entrypoint.sh
+++ b/11/jre/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jre/alpine/entrypoint.sh
+++ b/11/jre/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/ubi/ubi9-minimal/Dockerfile
+++ b/11/jre/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/11/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/11/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/ubuntu/focal/Dockerfile
+++ b/11/jre/ubuntu/focal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -98,4 +98,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/11/jre/ubuntu/focal/entrypoint.sh
+++ b/11/jre/ubuntu/focal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jre/ubuntu/focal/entrypoint.sh
+++ b/11/jre/ubuntu/focal/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/ubuntu/jammy/Dockerfile
+++ b/11/jre/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -98,4 +98,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/11/jre/ubuntu/jammy/entrypoint.sh
+++ b/11/jre/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jre/ubuntu/jammy/entrypoint.sh
+++ b/11/jre/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/ubuntu/noble/Dockerfile
+++ b/11/jre/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -98,4 +98,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/11/jre/ubuntu/noble/entrypoint.sh
+++ b/11/jre/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/11/jre/ubuntu/noble/entrypoint.sh
+++ b/11/jre/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/windows/nanoserver-1809/Dockerfile
+++ b/11/jre/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/11/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/windows/windowsservercore-1809/Dockerfile
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/11/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/11/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/alpine/Dockerfile
+++ b/17/jdk/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/alpine/entrypoint.sh
+++ b/17/jdk/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jdk/alpine/entrypoint.sh
+++ b/17/jdk/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/17/jdk/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/17/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/17/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/ubuntu/focal/Dockerfile
+++ b/17/jdk/ubuntu/focal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -103,6 +103,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/17/jdk/ubuntu/focal/entrypoint.sh
+++ b/17/jdk/ubuntu/focal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jdk/ubuntu/focal/entrypoint.sh
+++ b/17/jdk/ubuntu/focal/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/ubuntu/jammy/Dockerfile
+++ b/17/jdk/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -103,6 +103,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/17/jdk/ubuntu/jammy/entrypoint.sh
+++ b/17/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jdk/ubuntu/jammy/entrypoint.sh
+++ b/17/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/ubuntu/noble/Dockerfile
+++ b/17/jdk/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -103,6 +103,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/17/jdk/ubuntu/noble/entrypoint.sh
+++ b/17/jdk/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jdk/ubuntu/noble/entrypoint.sh
+++ b/17/jdk/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/windows/nanoserver-1809/Dockerfile
+++ b/17/jdk/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/17/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/17/jdk/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/17/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/alpine/Dockerfile
+++ b/17/jre/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/alpine/entrypoint.sh
+++ b/17/jre/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jre/alpine/entrypoint.sh
+++ b/17/jre/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/ubi/ubi9-minimal/Dockerfile
+++ b/17/jre/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/17/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/17/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/ubuntu/focal/Dockerfile
+++ b/17/jre/ubuntu/focal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -98,4 +98,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/17/jre/ubuntu/focal/entrypoint.sh
+++ b/17/jre/ubuntu/focal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jre/ubuntu/focal/entrypoint.sh
+++ b/17/jre/ubuntu/focal/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/ubuntu/jammy/Dockerfile
+++ b/17/jre/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -98,4 +98,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/17/jre/ubuntu/jammy/entrypoint.sh
+++ b/17/jre/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jre/ubuntu/jammy/entrypoint.sh
+++ b/17/jre/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/ubuntu/noble/Dockerfile
+++ b/17/jre/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -98,4 +98,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/17/jre/ubuntu/noble/entrypoint.sh
+++ b/17/jre/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/17/jre/ubuntu/noble/entrypoint.sh
+++ b/17/jre/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/windows/nanoserver-1809/Dockerfile
+++ b/17/jre/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/17/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/windows/windowsservercore-1809/Dockerfile
+++ b/17/jre/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/17/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/17/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/alpine/Dockerfile
+++ b/21/jdk/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/alpine/entrypoint.sh
+++ b/21/jdk/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/21/jdk/alpine/entrypoint.sh
+++ b/21/jdk/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/21/jdk/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/21/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/21/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/21/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/ubuntu/jammy/Dockerfile
+++ b/21/jdk/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -99,6 +99,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/21/jdk/ubuntu/jammy/entrypoint.sh
+++ b/21/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/21/jdk/ubuntu/jammy/entrypoint.sh
+++ b/21/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/ubuntu/noble/Dockerfile
+++ b/21/jdk/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -99,6 +99,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/21/jdk/ubuntu/noble/entrypoint.sh
+++ b/21/jdk/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/21/jdk/ubuntu/noble/entrypoint.sh
+++ b/21/jdk/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/windows/nanoserver-1809/Dockerfile
+++ b/21/jdk/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/21/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/21/jdk/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/21/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/alpine/Dockerfile
+++ b/21/jre/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/alpine/entrypoint.sh
+++ b/21/jre/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/21/jre/alpine/entrypoint.sh
+++ b/21/jre/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/ubi/ubi9-minimal/Dockerfile
+++ b/21/jre/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/21/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/21/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/21/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/ubuntu/jammy/Dockerfile
+++ b/21/jre/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -94,4 +94,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/21/jre/ubuntu/jammy/entrypoint.sh
+++ b/21/jre/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/21/jre/ubuntu/jammy/entrypoint.sh
+++ b/21/jre/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/ubuntu/noble/Dockerfile
+++ b/21/jre/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -94,4 +94,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/21/jre/ubuntu/noble/entrypoint.sh
+++ b/21/jre/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/21/jre/ubuntu/noble/entrypoint.sh
+++ b/21/jre/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/windows/nanoserver-1809/Dockerfile
+++ b/21/jre/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/21/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/windows/windowsservercore-1809/Dockerfile
+++ b/21/jre/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/21/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/21/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/alpine/Dockerfile
+++ b/22/jdk/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/alpine/entrypoint.sh
+++ b/22/jdk/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/22/jdk/alpine/entrypoint.sh
+++ b/22/jdk/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/22/jdk/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/22/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/22/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/22/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/ubuntu/jammy/Dockerfile
+++ b/22/jdk/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -97,6 +97,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/22/jdk/ubuntu/jammy/entrypoint.sh
+++ b/22/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/22/jdk/ubuntu/jammy/entrypoint.sh
+++ b/22/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/ubuntu/noble/Dockerfile
+++ b/22/jdk/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -97,6 +97,6 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 
 CMD ["jshell"]

--- a/22/jdk/ubuntu/noble/entrypoint.sh
+++ b/22/jdk/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/22/jdk/ubuntu/noble/entrypoint.sh
+++ b/22/jdk/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/windows/nanoserver-1809/Dockerfile
+++ b/22/jdk/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/22/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/22/jdk/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/22/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/alpine/Dockerfile
+++ b/22/jre/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/alpine/entrypoint.sh
+++ b/22/jre/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/22/jre/alpine/entrypoint.sh
+++ b/22/jre/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/ubi/ubi9-minimal/Dockerfile
+++ b/22/jre/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/22/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/22/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/22/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/ubuntu/jammy/Dockerfile
+++ b/22/jre/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -92,4 +92,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/22/jre/ubuntu/jammy/entrypoint.sh
+++ b/22/jre/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/22/jre/ubuntu/jammy/entrypoint.sh
+++ b/22/jre/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/ubuntu/noble/Dockerfile
+++ b/22/jre/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -92,4 +92,4 @@ RUN set -eux; \
     echo "java --version"; java --version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/22/jre/ubuntu/noble/entrypoint.sh
+++ b/22/jre/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/22/jre/ubuntu/noble/entrypoint.sh
+++ b/22/jre/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/windows/nanoserver-1809/Dockerfile
+++ b/22/jre/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/22/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/windows/windowsservercore-1809/Dockerfile
+++ b/22/jre/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/22/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/22/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/alpine/entrypoint.sh
+++ b/8/jdk/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jdk/alpine/entrypoint.sh
+++ b/8/jdk/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/8/jdk/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/8/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/8/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/ubuntu/focal/Dockerfile
+++ b/8/jdk/ubuntu/focal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -96,4 +96,4 @@ RUN set -eux; \
     echo "java -version"; java -version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/8/jdk/ubuntu/focal/entrypoint.sh
+++ b/8/jdk/ubuntu/focal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jdk/ubuntu/focal/entrypoint.sh
+++ b/8/jdk/ubuntu/focal/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/ubuntu/jammy/Dockerfile
+++ b/8/jdk/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -96,4 +96,4 @@ RUN set -eux; \
     echo "java -version"; java -version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/8/jdk/ubuntu/jammy/entrypoint.sh
+++ b/8/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jdk/ubuntu/jammy/entrypoint.sh
+++ b/8/jdk/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/ubuntu/noble/Dockerfile
+++ b/8/jdk/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -96,4 +96,4 @@ RUN set -eux; \
     echo "java -version"; java -version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/8/jdk/ubuntu/noble/entrypoint.sh
+++ b/8/jdk/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jdk/ubuntu/noble/entrypoint.sh
+++ b/8/jdk/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/windows/nanoserver-1809/Dockerfile
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/8/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/alpine/Dockerfile
+++ b/8/jre/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/alpine/entrypoint.sh
+++ b/8/jre/alpine/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jre/alpine/entrypoint.sh
+++ b/8/jre/alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/ubi/ubi9-minimal/Dockerfile
+++ b/8/jre/ubi/ubi9-minimal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/8/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-trust
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/8/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/ubuntu/focal/Dockerfile
+++ b/8/jre/ubuntu/focal/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -95,4 +95,4 @@ RUN set -eux; \
     echo "java -version"; java -version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/8/jre/ubuntu/focal/entrypoint.sh
+++ b/8/jre/ubuntu/focal/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jre/ubuntu/focal/entrypoint.sh
+++ b/8/jre/ubuntu/focal/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/ubuntu/jammy/Dockerfile
+++ b/8/jre/ubuntu/jammy/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -95,4 +95,4 @@ RUN set -eux; \
     echo "java -version"; java -version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/8/jre/ubuntu/jammy/entrypoint.sh
+++ b/8/jre/ubuntu/jammy/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jre/ubuntu/jammy/entrypoint.sh
+++ b/8/jre/ubuntu/jammy/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/ubuntu/noble/Dockerfile
+++ b/8/jre/ubuntu/noble/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
@@ -95,4 +95,4 @@ RUN set -eux; \
     echo "java -version"; java -version; \
     echo "Complete."
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]

--- a/8/jre/ubuntu/noble/entrypoint.sh
+++ b/8/jre/ubuntu/noble/entrypoint.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env sh
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +93,9 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            cp -La /certificates/* /usr/local/share/ca-certificates/
         fi
-
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/8/jre/ubuntu/noble/entrypoint.sh
+++ b/8/jre/ubuntu/noble/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/windows/nanoserver-1809/Dockerfile
+++ b/8/jre/windows/nanoserver-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/8/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/windows/windowsservercore-1809/Dockerfile
+++ b/8/jre/windows/windowsservercore-1809/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/8/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/config/hotspot.yml
+++ b/config/hotspot.yml
@@ -23,7 +23,6 @@ configurations:
     architectures: [aarch64, arm, ppc64le, s390x, x64]
     # `bash` is required for Ubuntu-based images to correctly resolve
     # environment variables.with.dots.in.them.
-    shebang: /bin/bash
     os: ubuntu
   
   - directory: ubuntu/jammy
@@ -32,7 +31,6 @@ configurations:
     deprecated: 23
     # `bash` is required for Ubuntu-based images to correctly resolve
     # environment variables.with.dots.in.them.
-    shebang: /bin/bash
     os: ubuntu
 
   - directory: ubuntu/focal
@@ -41,7 +39,6 @@ configurations:
     deprecated: 20
     # `bash` is required for Ubuntu-based images to correctly resolve
     # environment variables.with.dots.in.them.
-    shebang: /bin/bash
     os: ubuntu
 
   - directory: ubi/ubi9-minimal

--- a/docker_templates/entrypoint.sh.j2
+++ b/docker_templates/entrypoint.sh.j2
@@ -1,4 +1,8 @@
+{%- if os == "ubuntu" -%}
+#!/usr/bin/env bash
+{%- else -%}
 #!/usr/bin/env sh
+{%- endif %}
 {% include 'partials/license.j2' %}
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but

--- a/docker_templates/entrypoint.sh.j2
+++ b/docker_templates/entrypoint.sh.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+{% include 'partials/license.j2' %}
 # This script defines `sh` as the interpreter, which is available in all POSIX environments. However, it might get
 # started with `bash` as the shell to support dotted.environment.variable.names which are not supported by POSIX, but
 # are supported by `sh` in some Linux flavours.
@@ -75,27 +76,18 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-
-            # UBI
-            if [ -d /usr/share/pki/ca-trust-source/anchors/ ]; then
-                cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
-            fi
-
-            # Ubuntu/Alpine
-            if [ -d /usr/local/share/ca-certificates/ ]; then
-                cp -La /certificates/* /usr/local/share/ca-certificates/
-            fi
+            {%- if os == "ubuntu" or os == "alpine-linux" %}
+            cp -La /certificates/* /usr/local/share/ca-certificates/
+            {%- elif os == "ubi9-minimal" %}
+            cp -La /certificates/* /usr/share/pki/ca-trust-source/anchors/
+            {%- endif %}
         fi
 
-        # UBI
-        if command -v update-ca-trust >/dev/null; then
-            update-ca-trust
-        fi
-
-        # Ubuntu/Alpine
-        if command -v update-ca-certificates >/dev/null; then
-            update-ca-certificates
-        fi
+        {%- if os == "ubuntu" or os == "alpine-linux" %}
+        update-ca-certificates
+        {%- elif os == "ubi9-minimal" %}
+        update-ca-trust
+        {%- endif %}
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.
@@ -107,3 +99,4 @@ fi
 export JRE_CACERTS_PATH
 
 exec "$@"
+

--- a/docker_templates/partials/license.j2
+++ b/docker_templates/partials/license.j2
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#               NOTE: THIS DOCKERFILE IS GENERATED VIA "generate_dockerfiles.py"
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------

--- a/docker_templates/ubuntu.Dockerfile.j2
+++ b/docker_templates/ubuntu.Dockerfile.j2
@@ -43,5 +43,5 @@ ENV JAVA_VERSION {{ java_version }}
 {% endif %}
 {% include 'partials/version-check.j2' %}
 COPY entrypoint.sh /__cacert_entrypoint.sh
-ENTRYPOINT ["{{ shebang }}", "/__cacert_entrypoint.sh"]
+ENTRYPOINT ["/__cacert_entrypoint.sh"]
 {% include 'partials/jshell.j2' %}

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -177,12 +177,18 @@ for os_family, configurations in config["configurations"].items():
                     # Entrypoint is currently only needed for CA certificate handling, which is not (yet)
                     # available on Windows
 
-                    # Copy entrypoint.sh to output directory
-                    entrypoint_path = os.path.join("docker_templates", "entrypoint.sh")
+                    # Generate entrypoint.sh
+                    template_entrypoint_file = "entrypoint.sh.j2"
+                    template_entrypoint = env.get_template(template_entrypoint_file)
 
-                    if os.path.exists(entrypoint_path):
-                        os.system(
-                            f"cp {entrypoint_path} {os.path.join(output_directory, 'entrypoint.sh')}"
-                        )
+                    entrypoint = template_entrypoint.render(
+                        os=os_name
+                    )
+
+                    with open(
+                        os.path.join(output_directory, "entrypoint.sh"), "w"
+                    ) as out_file:
+                        out_file.write(entrypoint)
+                    os.chmod(os.path.join(output_directory, "entrypoint.sh"), 0o755)
 
 print("Dockerfiles generated successfully!")

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -74,7 +74,6 @@ for os_family, configurations in config["configurations"].items():
         directory = configuration["directory"]
         architectures = configuration["architectures"]
         os_name = configuration["os"]
-        shebang = configuration.get("shebang", "")
         base_image = configuration["image"]
         deprecated = configuration.get("deprecated", None)
         versions = configuration.get(
@@ -163,7 +162,6 @@ for os_family, configurations in config["configurations"].items():
                     arch_data=arch_data,
                     os_family=os_family,
                     os=os_name,
-                    shebang=shebang,
                 )
 
                 print("Writing Dockerfile to", output_directory)
@@ -182,7 +180,7 @@ for os_family, configurations in config["configurations"].items():
                     template_entrypoint = env.get_template(template_entrypoint_file)
 
                     entrypoint = template_entrypoint.render(
-                        os=os_name
+                        os=os_name,
                     )
 
                     with open(


### PR DESCRIPTION
This change simplifies the logic in the entrypoint.sh script as well as adds the required copyright header to the files