### PR TITLE
remove legacy ENV variables

### DIFF
--- a/11/jdk/alpine/Dockerfile
+++ b/11/jdk/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -45,7 +45,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/11/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/11/jdk/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/11/jdk/ubuntu/focal/Dockerfile
+++ b/11/jdk/ubuntu/focal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:20.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/11/jdk/ubuntu/jammy/Dockerfile
+++ b/11/jdk/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/11/jdk/ubuntu/noble/Dockerfile
+++ b/11/jdk/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/11/jdk/windows/nanoserver-1809/Dockerfile
+++ b/11/jdk/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 ENV JAVA_HOME C:\\openjdk-11
 # "ERROR: Access to the registry path is denied."

--- a/11/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/11/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 ENV JAVA_HOME C:\\openjdk-11
 # "ERROR: Access to the registry path is denied."

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_x64_windows_hotspot_11.0.24_8.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_x64_windows_hotspot_11.0.24_8.msi ; \

--- a/11/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/11/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_x64_windows_hotspot_11.0.24_8.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_x64_windows_hotspot_11.0.24_8.msi ; \

--- a/11/jre/alpine/Dockerfile
+++ b/11/jre/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -45,7 +45,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/11/jre/ubi/ubi9-minimal/Dockerfile
+++ b/11/jre/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/11/jre/ubuntu/focal/Dockerfile
+++ b/11/jre/ubuntu/focal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:20.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/11/jre/ubuntu/jammy/Dockerfile
+++ b/11/jre/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/11/jre/ubuntu/noble/Dockerfile
+++ b/11/jre/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/11/jre/windows/nanoserver-1809/Dockerfile
+++ b/11/jre/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 ENV JAVA_HOME C:\\openjdk-11
 # "ERROR: Access to the registry path is denied."

--- a/11/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/11/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 ENV JAVA_HOME C:\\openjdk-11
 # "ERROR: Access to the registry path is denied."

--- a/11/jre/windows/windowsservercore-1809/Dockerfile
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jre_x64_windows_hotspot_11.0.24_8.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jre_x64_windows_hotspot_11.0.24_8.msi ; \

--- a/11/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/11/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.24+8
+ENV JAVA_VERSION=jdk-11.0.24+8
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jre_x64_windows_hotspot_11.0.24_8.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jre_x64_windows_hotspot_11.0.24_8.msi ; \

--- a/17/jdk/alpine/Dockerfile
+++ b/17/jdk/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -48,7 +48,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/17/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/17/jdk/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/17/jdk/ubuntu/focal/Dockerfile
+++ b/17/jdk/ubuntu/focal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:20.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -49,7 +49,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/17/jdk/ubuntu/jammy/Dockerfile
+++ b/17/jdk/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -49,7 +49,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/17/jdk/ubuntu/noble/Dockerfile
+++ b/17/jdk/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -49,7 +49,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/17/jdk/windows/nanoserver-1809/Dockerfile
+++ b/17/jdk/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 ENV JAVA_HOME C:\\openjdk-17
 # "ERROR: Access to the registry path is denied."

--- a/17/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/17/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 ENV JAVA_HOME C:\\openjdk-17
 # "ERROR: Access to the registry path is denied."

--- a/17/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/17/jdk/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.12_7.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.12_7.msi ; \

--- a/17/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/17/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.12_7.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.12_7.msi ; \

--- a/17/jre/alpine/Dockerfile
+++ b/17/jre/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -45,7 +45,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/17/jre/ubi/ubi9-minimal/Dockerfile
+++ b/17/jre/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/17/jre/ubuntu/focal/Dockerfile
+++ b/17/jre/ubuntu/focal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:20.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/17/jre/ubuntu/jammy/Dockerfile
+++ b/17/jre/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/17/jre/ubuntu/noble/Dockerfile
+++ b/17/jre/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/17/jre/windows/nanoserver-1809/Dockerfile
+++ b/17/jre/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 ENV JAVA_HOME C:\\openjdk-17
 # "ERROR: Access to the registry path is denied."

--- a/17/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/17/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 ENV JAVA_HOME C:\\openjdk-17
 # "ERROR: Access to the registry path is denied."

--- a/17/jre/windows/windowsservercore-1809/Dockerfile
+++ b/17/jre/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_x64_windows_hotspot_17.0.12_7.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_x64_windows_hotspot_17.0.12_7.msi ; \

--- a/17/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/17/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-17.0.12+7
+ENV JAVA_VERSION=jdk-17.0.12+7
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_x64_windows_hotspot_17.0.12_7.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_x64_windows_hotspot_17.0.12_7.msi ; \

--- a/21/jdk/alpine/Dockerfile
+++ b/21/jdk/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -48,7 +48,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/21/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/21/jdk/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/21/jdk/ubuntu/jammy/Dockerfile
+++ b/21/jdk/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -49,7 +49,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/21/jdk/ubuntu/noble/Dockerfile
+++ b/21/jdk/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -49,7 +49,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/21/jdk/windows/nanoserver-1809/Dockerfile
+++ b/21/jdk/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 ENV JAVA_HOME C:\\openjdk-21
 # "ERROR: Access to the registry path is denied."

--- a/21/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/21/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 ENV JAVA_HOME C:\\openjdk-21
 # "ERROR: Access to the registry path is denied."

--- a/21/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/21/jdk/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_windows_hotspot_21.0.4_7.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_windows_hotspot_21.0.4_7.msi ; \

--- a/21/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/21/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_windows_hotspot_21.0.4_7.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_windows_hotspot_21.0.4_7.msi ; \

--- a/21/jre/alpine/Dockerfile
+++ b/21/jre/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -45,7 +45,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/21/jre/ubi/ubi9-minimal/Dockerfile
+++ b/21/jre/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/21/jre/ubuntu/jammy/Dockerfile
+++ b/21/jre/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/21/jre/ubuntu/noble/Dockerfile
+++ b/21/jre/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/21/jre/windows/nanoserver-1809/Dockerfile
+++ b/21/jre/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 ENV JAVA_HOME C:\\openjdk-21
 # "ERROR: Access to the registry path is denied."

--- a/21/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/21/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 ENV JAVA_HOME C:\\openjdk-21
 # "ERROR: Access to the registry path is denied."

--- a/21/jre/windows/windowsservercore-1809/Dockerfile
+++ b/21/jre/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jre_x64_windows_hotspot_21.0.4_7.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jre_x64_windows_hotspot_21.0.4_7.msi ; \

--- a/21/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/21/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-21.0.4+7
+ENV JAVA_VERSION=jdk-21.0.4+7
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jre_x64_windows_hotspot_21.0.4_7.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jre_x64_windows_hotspot_21.0.4_7.msi ; \

--- a/22/jdk/alpine/Dockerfile
+++ b/22/jdk/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -48,7 +48,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/22/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/22/jdk/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/22/jdk/ubuntu/jammy/Dockerfile
+++ b/22/jdk/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -47,7 +47,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/22/jdk/ubuntu/noble/Dockerfile
+++ b/22/jdk/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -47,7 +47,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/22/jdk/windows/nanoserver-1809/Dockerfile
+++ b/22/jdk/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 ENV JAVA_HOME C:\\openjdk-22
 # "ERROR: Access to the registry path is denied."

--- a/22/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/22/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 ENV JAVA_HOME C:\\openjdk-22
 # "ERROR: Access to the registry path is denied."

--- a/22/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/22/jdk/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_windows_hotspot_22.0.2_9.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_windows_hotspot_22.0.2_9.msi ; \

--- a/22/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/22/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_windows_hotspot_22.0.2_9.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_windows_hotspot_22.0.2_9.msi ; \

--- a/22/jre/alpine/Dockerfile
+++ b/22/jre/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -45,7 +45,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/22/jre/ubi/ubi9-minimal/Dockerfile
+++ b/22/jre/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/22/jre/ubuntu/jammy/Dockerfile
+++ b/22/jre/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/22/jre/ubuntu/noble/Dockerfile
+++ b/22/jre/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/22/jre/windows/nanoserver-1809/Dockerfile
+++ b/22/jre/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 ENV JAVA_HOME C:\\openjdk-22
 # "ERROR: Access to the registry path is denied."

--- a/22/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/22/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 ENV JAVA_HOME C:\\openjdk-22
 # "ERROR: Access to the registry path is denied."

--- a/22/jre/windows/windowsservercore-1809/Dockerfile
+++ b/22/jre/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jre_x64_windows_hotspot_22.0.2_9.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jre_x64_windows_hotspot_22.0.2_9.msi ; \

--- a/22/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/22/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-22.0.2+9
+ENV JAVA_VERSION=jdk-22.0.2+9
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jre_x64_windows_hotspot_22.0.2_9.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jre_x64_windows_hotspot_22.0.2_9.msi ; \

--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -45,7 +45,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/8/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/8/jdk/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/8/jdk/ubuntu/focal/Dockerfile
+++ b/8/jdk/ubuntu/focal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:20.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/8/jdk/ubuntu/jammy/Dockerfile
+++ b/8/jdk/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/8/jdk/ubuntu/noble/Dockerfile
+++ b/8/jdk/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/8/jdk/windows/nanoserver-1809/Dockerfile
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 ENV JAVA_HOME C:\\openjdk-8
 # "ERROR: Access to the registry path is denied."

--- a/8/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/8/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 ENV JAVA_HOME C:\\openjdk-8
 # "ERROR: Access to the registry path is denied."

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_x64_windows_hotspot_8u422b05.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_x64_windows_hotspot_8u422b05.msi ; \

--- a/8/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_x64_windows_hotspot_8u422b05.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_x64_windows_hotspot_8u422b05.msi ; \

--- a/8/jre/alpine/Dockerfile
+++ b/8/jre/alpine/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM alpine:3.20
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -45,7 +45,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \

--- a/8/jre/ubi/ubi9-minimal/Dockerfile
+++ b/8/jre/ubi/ubi9-minimal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM redhat/ubi9-minimal
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -44,7 +44,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \

--- a/8/jre/ubuntu/focal/Dockerfile
+++ b/8/jre/ubuntu/focal/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:20.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/8/jre/ubuntu/jammy/Dockerfile
+++ b/8/jre/ubuntu/jammy/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/8/jre/ubuntu/noble/Dockerfile
+++ b/8/jre/ubuntu/noble/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:24.04
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -46,7 +46,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \

--- a/8/jre/windows/nanoserver-1809/Dockerfile
+++ b/8/jre/windows/nanoserver-1809/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 ENV JAVA_HOME C:\\openjdk-8
 # "ERROR: Access to the registry path is denied."

--- a/8/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/8/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 ENV JAVA_HOME C:\\openjdk-8
 # "ERROR: Access to the registry path is denied."

--- a/8/jre/windows/windowsservercore-1809/Dockerfile
+++ b/8/jre/windows/windowsservercore-1809/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jre_x64_windows_hotspot_8u422b05.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jre_x64_windows_hotspot_8u422b05.msi ; \

--- a/8/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,7 +22,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u422-b05
+ENV JAVA_VERSION=jdk8u422-b05
 
 RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jre_x64_windows_hotspot_8u422b05.msi ...'); \
     curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jre_x64_windows_hotspot_8u422b05.msi ; \

--- a/docker_templates/alpine-linux.Dockerfile.j2
+++ b/docker_templates/alpine-linux.Dockerfile.j2
@@ -25,7 +25,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION {{ java_version }}
+{% include 'partials/java-version.j2' %}
 
 {% include 'partials/multi-arch-install.j2' %}
 

--- a/docker_templates/nanoserver.Dockerfile.j2
+++ b/docker_templates/nanoserver.Dockerfile.j2
@@ -4,7 +4,7 @@ FROM {{ base_image }}
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION {{ java_version }}
+{% include 'partials/java-version.j2' %}
 
 ENV JAVA_HOME C:\\openjdk-{{ version }}
 # "ERROR: Access to the registry path is denied."

--- a/docker_templates/partials/java-version.j2
+++ b/docker_templates/partials/java-version.j2
@@ -1,0 +1,1 @@
+ENV JAVA_VERSION={{ java_version }}

--- a/docker_templates/partials/nix-env.j2
+++ b/docker_templates/partials/nix-env.j2
@@ -1,5 +1,5 @@
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'

--- a/docker_templates/servercore.Dockerfile.j2
+++ b/docker_templates/servercore.Dockerfile.j2
@@ -5,7 +5,7 @@ FROM {{ base_image }}
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION {{ java_version }}
+{% include 'partials/java-version.j2' %}
 
 RUN Write-Host ('Downloading {{ arch_data.download_url }} ...'); \
     curl.exe -LfsSo openjdk.msi {{ arch_data.download_url }} ; \

--- a/docker_templates/ubi9-minimal.Dockerfile.j2
+++ b/docker_templates/ubi9-minimal.Dockerfile.j2
@@ -23,7 +23,7 @@ RUN set -eux; \
     ; \
     microdnf clean all
 
-ENV JAVA_VERSION {{ java_version }}
+{% include 'partials/java-version.j2' %}
 
 {% include 'partials/multi-arch-install.j2' %}
 

--- a/docker_templates/ubuntu.Dockerfile.j2
+++ b/docker_templates/ubuntu.Dockerfile.j2
@@ -28,7 +28,7 @@ RUN set -eux; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION {{ java_version }}
+{% include 'partials/java-version.j2' %}
 
 {% include 'partials/multi-arch-install.j2' %} \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472

--- a/dockerhub_doc_config_update.sh
+++ b/dockerhub_doc_config_update.sh
@@ -63,7 +63,7 @@ print_official_header() {
 
 function generate_official_image_tags() {
 	# Generate the tags
-	full_version=$(grep "VERSION" "${file}" | awk '{ print $3 }')
+	full_version=$(grep "JAVA_VERSION=" "${file}" | awk '{ print $2 }' | awk -F '=' '{ print $2 }')
 
 	# Remove any `jdk` references in the version
 	ojdk_version=$(echo "${full_version}" | sed 's/\(jdk-\)//;s/\(jdk\)//' | awk -F '_' '{ print $1 }')

--- a/dockerhub_doc_config_update.sh
+++ b/dockerhub_doc_config_update.sh
@@ -63,7 +63,7 @@ print_official_header() {
 
 function generate_official_image_tags() {
 	# Generate the tags
-	full_version=$(grep "JAVA_VERSION=" "${file}" | awk '{ print $2 }' | awk -F '=' '{ print $2 }')
+	full_version=$(grep "JAVA_VERSION=" "${file}" | awk -F '=' '{ print $2 }')
 
 	# Remove any `jdk` references in the version
 	ojdk_version=$(echo "${full_version}" | sed 's/\(jdk-\)//;s/\(jdk\)//' | awk -F '_' '{ print $1 }')


### PR DESCRIPTION
removes the following warnings:

```output
 3 warnings found (use --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 22)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 23)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 48)
Dockerfile:50
```

refer to https://docs.docker.com/reference/dockerfile/#environment-replacement for the reference