### PR TITLE
correct location to src.zip

### DIFF
--- a/11/jre/alpine/Dockerfile
+++ b/11/jre/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/11/jre/ubi/ubi9-minimal/Dockerfile
+++ b/11/jre/ubi/ubi9-minimal/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/11/jre/ubuntu/focal/Dockerfile
+++ b/11/jre/ubuntu/focal/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/11/jre/ubuntu/jammy/Dockerfile
+++ b/11/jre/ubuntu/jammy/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/11/jre/ubuntu/noble/Dockerfile
+++ b/11/jre/ubuntu/noble/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/17/jre/alpine/Dockerfile
+++ b/17/jre/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/17/jre/ubi/ubi9-minimal/Dockerfile
+++ b/17/jre/ubi/ubi9-minimal/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/17/jre/ubuntu/focal/Dockerfile
+++ b/17/jre/ubuntu/focal/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/17/jre/ubuntu/jammy/Dockerfile
+++ b/17/jre/ubuntu/jammy/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/17/jre/ubuntu/noble/Dockerfile
+++ b/17/jre/ubuntu/noble/Dockerfile
@@ -97,7 +97,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/21/jre/alpine/Dockerfile
+++ b/21/jre/alpine/Dockerfile
@@ -80,7 +80,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/21/jre/ubi/ubi9-minimal/Dockerfile
+++ b/21/jre/ubi/ubi9-minimal/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/21/jre/ubuntu/jammy/Dockerfile
+++ b/21/jre/ubuntu/jammy/Dockerfile
@@ -89,7 +89,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/21/jre/ubuntu/noble/Dockerfile
+++ b/21/jre/ubuntu/noble/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/23/jre/alpine/Dockerfile
+++ b/23/jre/alpine/Dockerfile
@@ -80,7 +80,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/23/jre/ubi/ubi9-minimal/Dockerfile
+++ b/23/jre/ubi/ubi9-minimal/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/23/jre/ubuntu/noble/Dockerfile
+++ b/23/jre/ubuntu/noble/Dockerfile
@@ -91,7 +91,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \

--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/8/jdk/ubi/ubi9-minimal/Dockerfile
+++ b/8/jdk/ubi/ubi9-minimal/Dockerfile
@@ -81,7 +81,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/8/jdk/ubuntu/focal/Dockerfile
+++ b/8/jdk/ubuntu/focal/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/8/jdk/ubuntu/jammy/Dockerfile
+++ b/8/jdk/ubuntu/jammy/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/8/jdk/ubuntu/noble/Dockerfile
+++ b/8/jdk/ubuntu/noble/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/8/jre/alpine/Dockerfile
+++ b/8/jre/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/8/jre/ubi/ubi9-minimal/Dockerfile
+++ b/8/jre/ubi/ubi9-minimal/Dockerfile
@@ -81,7 +81,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    rm -f /tmp/openjdk.tar.gz;
 
 RUN set -eux; \
     echo "Verifying install ..."; \

--- a/8/jre/ubuntu/focal/Dockerfile
+++ b/8/jre/ubuntu/focal/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/8/jre/ubuntu/jammy/Dockerfile
+++ b/8/jre/ubuntu/jammy/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/8/jre/ubuntu/noble/Dockerfile
+++ b/8/jre/ubuntu/noble/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip; \
+    rm -f /tmp/openjdk.tar.gz; \
     # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
     find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig;

--- a/docker_templates/partials/multi-arch-install.j2
+++ b/docker_templates/partials/multi-arch-install.j2
@@ -33,4 +33,8 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/lib/src.zip;
+    {%- if version|int == 8 %}
+    rm -f /tmp/openjdk.tar.gz{% if image_type == "jdk" %} ${JAVA_HOME}/src.zip{% endif %};
+    {%- else %}
+    rm -f /tmp/openjdk.tar.gz{% if image_type == "jdk" %} ${JAVA_HOME}/lib/src.zip{% endif %};
+    {%- endif %}


### PR DESCRIPTION
fixes: https://github.com/adoptium/containers/issues/472

On JDK11+ the location is `${JAVA_HOME}/lib/src.zip`
On JDK8 the location is `${JAVA_HOME}/src.zip`

For JREs the src.zip will never exist so we shouldn't be trying to delete it

A simple way to test this on JDK8u (showing that the src.zip is still present)

```bash
 docker run -it eclipse-temurin:8-jdk-alpine find ${JAVA_HOME} -name src.zip
./opt/java/openjdk/src.zip
```