### PR TITLE
add git attributes to flag generated items

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/*/**/Dockerfile linguist-generated
+docker_templates/*Dockerfile.j2 linguist-language=Dockerfile


### PR DESCRIPTION
by flagging the generated dockerfiles as `linguist-generated` it means they won't automatically be rendered in git diffs which will make reviewing far easier.