### PR TITLE
prevent alpine linux latest tag

### DIFF
--- a/dockerhub_doc_config_update.sh
+++ b/dockerhub_doc_config_update.sh
@@ -96,7 +96,7 @@ function generate_official_image_tags() {
 		# make "eclipse-temurin:latest" point to newest supported JDK
 		# shellcheck disable=SC2154
 		if [ "${ver}" == "${latest_version}" ]; then
-			if [ "${vm}" == "hotspot" ]; then
+			if [ "${vm}" == "hotspot" ] && [ "${os}" != "alpine" ]; then
 				extra_shared_tags=", latest"
 			fi
 		fi


### PR DESCRIPTION
prevents the latest tag being used for alpine linux which would conflict with the Ubuntu latest tag