### PR TITLE
Clean certificate files to not fail on comments

### DIFF
--- a/11/jdk/alpine/3.20/entrypoint.sh
+++ b/11/jdk/alpine/3.20/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jdk/alpine/3.21/entrypoint.sh
+++ b/11/jdk/alpine/3.21/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/11/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jdk/ubuntu/focal/entrypoint.sh
+++ b/11/jdk/ubuntu/focal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jdk/ubuntu/jammy/entrypoint.sh
+++ b/11/jdk/ubuntu/jammy/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jdk/ubuntu/noble/entrypoint.sh
+++ b/11/jdk/ubuntu/noble/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jre/alpine/3.20/entrypoint.sh
+++ b/11/jre/alpine/3.20/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jre/alpine/3.21/entrypoint.sh
+++ b/11/jre/alpine/3.21/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/11/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jre/ubuntu/focal/entrypoint.sh
+++ b/11/jre/ubuntu/focal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jre/ubuntu/jammy/entrypoint.sh
+++ b/11/jre/ubuntu/jammy/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/11/jre/ubuntu/noble/entrypoint.sh
+++ b/11/jre/ubuntu/noble/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jdk/alpine/3.20/entrypoint.sh
+++ b/17/jdk/alpine/3.20/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jdk/alpine/3.21/entrypoint.sh
+++ b/17/jdk/alpine/3.21/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/17/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jdk/ubuntu/focal/entrypoint.sh
+++ b/17/jdk/ubuntu/focal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jdk/ubuntu/jammy/entrypoint.sh
+++ b/17/jdk/ubuntu/jammy/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jdk/ubuntu/noble/entrypoint.sh
+++ b/17/jdk/ubuntu/noble/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jre/alpine/3.20/entrypoint.sh
+++ b/17/jre/alpine/3.20/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jre/alpine/3.21/entrypoint.sh
+++ b/17/jre/alpine/3.21/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/17/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jre/ubuntu/focal/entrypoint.sh
+++ b/17/jre/ubuntu/focal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jre/ubuntu/jammy/entrypoint.sh
+++ b/17/jre/ubuntu/jammy/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/17/jre/ubuntu/noble/entrypoint.sh
+++ b/17/jre/ubuntu/noble/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jdk/alpine/3.20/entrypoint.sh
+++ b/21/jdk/alpine/3.20/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jdk/alpine/3.21/entrypoint.sh
+++ b/21/jdk/alpine/3.21/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/21/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jdk/ubuntu/jammy/entrypoint.sh
+++ b/21/jdk/ubuntu/jammy/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jdk/ubuntu/noble/entrypoint.sh
+++ b/21/jdk/ubuntu/noble/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jre/alpine/3.20/entrypoint.sh
+++ b/21/jre/alpine/3.20/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jre/alpine/3.21/entrypoint.sh
+++ b/21/jre/alpine/3.21/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/21/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jre/ubuntu/jammy/entrypoint.sh
+++ b/21/jre/ubuntu/jammy/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/21/jre/ubuntu/noble/entrypoint.sh
+++ b/21/jre/ubuntu/noble/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/23/jdk/alpine/3.20/entrypoint.sh
+++ b/23/jdk/alpine/3.20/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/23/jdk/alpine/3.21/entrypoint.sh
+++ b/23/jdk/alpine/3.21/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/23/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/23/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/23/jdk/ubuntu/noble/entrypoint.sh
+++ b/23/jdk/ubuntu/noble/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/23/jre/alpine/3.20/entrypoint.sh
+++ b/23/jre/alpine/3.20/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/23/jre/alpine/3.21/entrypoint.sh
+++ b/23/jre/alpine/3.21/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/23/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/23/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/23/jre/ubuntu/noble/entrypoint.sh
+++ b/23/jre/ubuntu/noble/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jdk/alpine/3.20/entrypoint.sh
+++ b/8/jdk/alpine/3.20/entrypoint.sh
@@ -72,7 +72,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jdk/alpine/3.20/entrypoint.sh
+++ b/8/jdk/alpine/3.20/entrypoint.sh
@@ -70,13 +70,18 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
 
         # We might have multiple certificates in the file. Split this file into single files. The reason is that
         # `keytool` does not accept multi-certificate files
-        csplit -s -z -b %02d.crt -f "$tmp_dir/$BASENAME-" "$i" '/-----BEGIN CERTIFICATE-----/' '{*}'
+        awk '
+            BEGIN { file = "/dev/null" }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            { print $0 >> file }
+            /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
+        ' < "$i"
 
         for crt in "$tmp_dir/$BASENAME"-*; do
             # Extract the Common Name (CN) and Serial Number from the certificate
             CN=$(openssl x509 -in "$crt" -noout -subject -nameopt -space_eq | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
             SERIAL=$(openssl x509 -in "$crt" -noout -serial | sed -n 's/^serial=\(.*\)$/\1/p')
-            
+
             # Check if an alias with the CN already exists in the keystore
             ALIAS=$CN
             if keytool -list -keystore "$JRE_CACERTS_PATH" -storepass changeit -alias "$ALIAS" >/dev/null 2>&1; then

--- a/8/jdk/alpine/3.21/entrypoint.sh
+++ b/8/jdk/alpine/3.21/entrypoint.sh
@@ -72,7 +72,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jdk/alpine/3.21/entrypoint.sh
+++ b/8/jdk/alpine/3.21/entrypoint.sh
@@ -70,13 +70,18 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
 
         # We might have multiple certificates in the file. Split this file into single files. The reason is that
         # `keytool` does not accept multi-certificate files
-        csplit -s -z -b %02d.crt -f "$tmp_dir/$BASENAME-" "$i" '/-----BEGIN CERTIFICATE-----/' '{*}'
+        awk '
+            BEGIN { file = "/dev/null" }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            { print $0 >> file }
+            /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
+        ' < "$i"
 
         for crt in "$tmp_dir/$BASENAME"-*; do
             # Extract the Common Name (CN) and Serial Number from the certificate
             CN=$(openssl x509 -in "$crt" -noout -subject -nameopt -space_eq | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
             SERIAL=$(openssl x509 -in "$crt" -noout -serial | sed -n 's/^serial=\(.*\)$/\1/p')
-            
+
             # Check if an alias with the CN already exists in the keystore
             ALIAS=$CN
             if keytool -list -keystore "$JRE_CACERTS_PATH" -storepass changeit -alias "$ALIAS" >/dev/null 2>&1; then

--- a/8/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/8/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -72,7 +72,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jdk/ubi/ubi9-minimal/entrypoint.sh
+++ b/8/jdk/ubi/ubi9-minimal/entrypoint.sh
@@ -70,13 +70,18 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
 
         # We might have multiple certificates in the file. Split this file into single files. The reason is that
         # `keytool` does not accept multi-certificate files
-        csplit -s -z -b %02d.crt -f "$tmp_dir/$BASENAME-" "$i" '/-----BEGIN CERTIFICATE-----/' '{*}'
+        awk '
+            BEGIN { file = "/dev/null" }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            { print $0 >> file }
+            /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
+        ' < "$i"
 
         for crt in "$tmp_dir/$BASENAME"-*; do
             # Extract the Common Name (CN) and Serial Number from the certificate
             CN=$(openssl x509 -in "$crt" -noout -subject -nameopt -space_eq | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
             SERIAL=$(openssl x509 -in "$crt" -noout -serial | sed -n 's/^serial=\(.*\)$/\1/p')
-            
+
             # Check if an alias with the CN already exists in the keystore
             ALIAS=$CN
             if keytool -list -keystore "$JRE_CACERTS_PATH" -storepass changeit -alias "$ALIAS" >/dev/null 2>&1; then

--- a/8/jdk/ubuntu/focal/entrypoint.sh
+++ b/8/jdk/ubuntu/focal/entrypoint.sh
@@ -72,7 +72,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jdk/ubuntu/focal/entrypoint.sh
+++ b/8/jdk/ubuntu/focal/entrypoint.sh
@@ -70,13 +70,18 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
 
         # We might have multiple certificates in the file. Split this file into single files. The reason is that
         # `keytool` does not accept multi-certificate files
-        csplit -s -z -b %02d.crt -f "$tmp_dir/$BASENAME-" "$i" '/-----BEGIN CERTIFICATE-----/' '{*}'
+        awk '
+            BEGIN { file = "/dev/null" }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            { print $0 >> file }
+            /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
+        ' < "$i"
 
         for crt in "$tmp_dir/$BASENAME"-*; do
             # Extract the Common Name (CN) and Serial Number from the certificate
             CN=$(openssl x509 -in "$crt" -noout -subject -nameopt -space_eq | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
             SERIAL=$(openssl x509 -in "$crt" -noout -serial | sed -n 's/^serial=\(.*\)$/\1/p')
-            
+
             # Check if an alias with the CN already exists in the keystore
             ALIAS=$CN
             if keytool -list -keystore "$JRE_CACERTS_PATH" -storepass changeit -alias "$ALIAS" >/dev/null 2>&1; then

--- a/8/jdk/ubuntu/jammy/entrypoint.sh
+++ b/8/jdk/ubuntu/jammy/entrypoint.sh
@@ -72,7 +72,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jdk/ubuntu/jammy/entrypoint.sh
+++ b/8/jdk/ubuntu/jammy/entrypoint.sh
@@ -70,13 +70,18 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
 
         # We might have multiple certificates in the file. Split this file into single files. The reason is that
         # `keytool` does not accept multi-certificate files
-        csplit -s -z -b %02d.crt -f "$tmp_dir/$BASENAME-" "$i" '/-----BEGIN CERTIFICATE-----/' '{*}'
+        awk '
+            BEGIN { file = "/dev/null" }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            { print $0 >> file }
+            /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
+        ' < "$i"
 
         for crt in "$tmp_dir/$BASENAME"-*; do
             # Extract the Common Name (CN) and Serial Number from the certificate
             CN=$(openssl x509 -in "$crt" -noout -subject -nameopt -space_eq | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
             SERIAL=$(openssl x509 -in "$crt" -noout -serial | sed -n 's/^serial=\(.*\)$/\1/p')
-            
+
             # Check if an alias with the CN already exists in the keystore
             ALIAS=$CN
             if keytool -list -keystore "$JRE_CACERTS_PATH" -storepass changeit -alias "$ALIAS" >/dev/null 2>&1; then

--- a/8/jdk/ubuntu/noble/entrypoint.sh
+++ b/8/jdk/ubuntu/noble/entrypoint.sh
@@ -72,7 +72,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jdk/ubuntu/noble/entrypoint.sh
+++ b/8/jdk/ubuntu/noble/entrypoint.sh
@@ -70,13 +70,18 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
 
         # We might have multiple certificates in the file. Split this file into single files. The reason is that
         # `keytool` does not accept multi-certificate files
-        csplit -s -z -b %02d.crt -f "$tmp_dir/$BASENAME-" "$i" '/-----BEGIN CERTIFICATE-----/' '{*}'
+        awk '
+            BEGIN { file = "/dev/null" }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            { print $0 >> file }
+            /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
+        ' < "$i"
 
         for crt in "$tmp_dir/$BASENAME"-*; do
             # Extract the Common Name (CN) and Serial Number from the certificate
             CN=$(openssl x509 -in "$crt" -noout -subject -nameopt -space_eq | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
             SERIAL=$(openssl x509 -in "$crt" -noout -serial | sed -n 's/^serial=\(.*\)$/\1/p')
-            
+
             # Check if an alias with the CN already exists in the keystore
             ALIAS=$CN
             if keytool -list -keystore "$JRE_CACERTS_PATH" -storepass changeit -alias "$ALIAS" >/dev/null 2>&1; then

--- a/8/jre/alpine/3.20/entrypoint.sh
+++ b/8/jre/alpine/3.20/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jre/alpine/3.21/entrypoint.sh
+++ b/8/jre/alpine/3.21/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jre/ubi/ubi9-minimal/entrypoint.sh
+++ b/8/jre/ubi/ubi9-minimal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jre/ubuntu/focal/entrypoint.sh
+++ b/8/jre/ubuntu/focal/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jre/ubuntu/jammy/entrypoint.sh
+++ b/8/jre/ubuntu/jammy/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/8/jre/ubuntu/noble/entrypoint.sh
+++ b/8/jre/ubuntu/noble/entrypoint.sh
@@ -71,7 +71,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"

--- a/docker_templates/entrypoint.sh.j2
+++ b/docker_templates/entrypoint.sh.j2
@@ -61,13 +61,18 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
 
         # We might have multiple certificates in the file. Split this file into single files. The reason is that
         # `keytool` does not accept multi-certificate files
-        csplit -s -z -b %02d.crt -f "$tmp_dir/$BASENAME-" "$i" '/-----BEGIN CERTIFICATE-----/' '{*}'
+        awk '
+            BEGIN { file = "/dev/null" }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            { print $0 >> file }
+            /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
+        ' < "$i"
 
         for crt in "$tmp_dir/$BASENAME"-*; do
             # Extract the Common Name (CN) and Serial Number from the certificate
             CN=$(openssl x509 -in "$crt" -noout -subject -nameopt -space_eq | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
             SERIAL=$(openssl x509 -in "$crt" -noout -serial | sed -n 's/^serial=\(.*\)$/\1/p')
-            
+
             # Check if an alias with the CN already exists in the keystore
             ALIAS=$CN
             if keytool -list -keystore "$JRE_CACERTS_PATH" -storepass changeit -alias "$ALIAS" >/dev/null 2>&1; then

--- a/docker_templates/entrypoint.sh.j2
+++ b/docker_templates/entrypoint.sh.j2
@@ -63,7 +63,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # `keytool` does not accept multi-certificate files
         awk '
             BEGIN { file = "/dev/null" }
-            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02.crt", idx) }
+            /^-----BEGIN CERTIFICATE-----$/ { file = sprintf("'"$tmp_dir/$BASENAME-"'%02d.crt", idx) }
             { print $0 >> file }
             /^-----END CERTIFICATE-----$/ { file = "/dev/null"; idx++ }
         ' < "$i"


### PR DESCRIPTION
This change allows loading a wider variety of certificate files from /certificates.

Currently, when there is any content before the first `-----BEGIN CERTIFICATE-----`, it will be extracted into the `*00.crt` file by csplit. Then the first `keytool -import` call will fail, because it rightly cannot find any certificate in that file.

In our case we have comment lines before the certificates to make managing multiple certificates in one pem file easier.

The change introduces an awk script that throws away any lines outside of BEGIN/END CERTIFICATE and, for simplicity, also replaces the functionality of csplit to extract the certificates into multiple individual files.