### PR TITLE
fix: Temurin images contain packages only used at container build time

### DIFF
--- a/docker_templates/alpine-linux.Dockerfile.j2
+++ b/docker_templates/alpine-linux.Dockerfile.j2
@@ -10,8 +10,10 @@ RUN set -eux; \
         # java.lang.NoClassDefFoundError: Could not initialize class sun.awt.X11FontManager
         # https://github.com/docker-library/openjdk/pull/235#issuecomment-424466077
         fontconfig ttf-dejavu \
+        {% if version|int < 25 -%}
         # gnupg required to verify the signature
         gnupg \
+        {% endif -%}
         # utilities for keeping Alpine and OpenJDK CA certificates in sync
         # https://github.com/adoptium/containers/issues/293
         ca-certificates p11-kit-trust \

--- a/docker_templates/partials/arch-variable.j2
+++ b/docker_templates/partials/arch-variable.j2
@@ -1,7 +1,7 @@
 {%- if os == "ubuntu" %}
-    ARCH="$(dpkg --print-architecture)"; \
+    ARCH="$(dpkg --print-architecture)";
 {%- elif os == "alpine-linux" %}
-    ARCH="$(apk --print-arch)"; \
+    ARCH="$(apk --print-arch)";
 {%- elif os == "ubi9-minimal" %}
-    ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"; \
+    ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)";
 {%- endif -%}

--- a/docker_templates/partials/multi-arch-install.j2
+++ b/docker_templates/partials/multi-arch-install.j2
@@ -1,11 +1,12 @@
 RUN set -eux; \
-{%- include 'partials/arch-variable.j2' %}
+{%- include 'partials/arch-variable.j2' %} \
+{%- set ver = version|int %}
     case "${ARCH}" in \
-       {% for architecture, details in arch_data.items() -%}
-        {{ architecture }}) \
+       {% for arch, details in arch_data.items() -%}
+        {{ arch }}) \
          ESUM='{{ details.checksum }}'; \
          BINARY_URL='{{ details.download_url }}'; \
-         {% if architecture == "armhf" and os == "ubuntu" and version|int == 8 -%}
+         {% if arch == "armhf" and os == "ubuntu" and ver == 8 -%}
          # Fixes libatomic.so.1: cannot open shared object file
          apt-get update; \
          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libatomic1; \
@@ -18,6 +19,15 @@ RUN set -eux; \
          exit 1; \
          ;; \
     esac; \
+    {%- if ver > 24 %}
+    {%- if os == "alpine-linux" %}
+    apk add --no-cache --virtual .fetch-deps gnupg; \
+    {%- elif os == "ubuntu" %}
+    savedAptMark="$(apt-mark showmanual)"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends wget gnupg; \
+    {%- endif %}
+    {%- endif %}
     wget {% if os != "alpine-linux" %}--progress=dot:giga {% endif %}-O /tmp/openjdk.tar.gz ${BINARY_URL}; \
     wget {% if os != "alpine-linux" %}--progress=dot:giga {% endif %}-O /tmp/openjdk.tar.gz.sig ${BINARY_URL}.sig; \
     export GNUPGHOME="$(mktemp -d)"; \
@@ -33,8 +43,20 @@ RUN set -eux; \
         --strip-components 1 \
         --no-same-owner \
     ; \
-    {%- if version|int == 8 %}
+    {%- if ver == 8 %}
     rm -f /tmp/openjdk.tar.gz{% if image_type == "jdk" %} ${JAVA_HOME}/src.zip{% endif %};
     {%- else %}
     rm -f /tmp/openjdk.tar.gz{% if image_type == "jdk" %} ${JAVA_HOME}/lib/src.zip{% endif %};
+    {%- if ver > 24 -%}
+    {%- if os == "alpine-linux" -%}
+    {{ " " }}\
+    apk del --no-network .fetch-deps;
+    {%- elif os == "ubuntu" -%}
+    {{ " " }}\
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark > /dev/null; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*;
+    {%- endif %}
+    {%- endif %}
     {%- endif %}

--- a/docker_templates/ubuntu.Dockerfile.j2
+++ b/docker_templates/ubuntu.Dockerfile.j2
@@ -11,9 +11,11 @@ RUN set -eux; \
         # curl required for historical reasons, see https://github.com/adoptium/containers/issues/255
         curl \
         {% endif -%}
+        {% if version|int < 25 -%}
         wget \
         # gnupg required to verify the signature
         gnupg \
+        {% endif -%}
         # java.lang.UnsatisfiedLinkError: libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
         # java.lang.NoClassDefFoundError: Could not initialize class sun.awt.X11FontManager
         # https://github.com/docker-library/openjdk/pull/235#issuecomment-424466077

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -11,12 +11,12 @@
 # limitations under the License.
 #
 
-import os
-
 import argparse
+import os
 import shutil
-import requests_cache
+
 import requests
+import requests_cache
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
@@ -27,7 +27,9 @@ parser = argparse.ArgumentParser(
 )
 
 # Setup the Jinja2 environment
-env = Environment(loader=FileSystemLoader("docker_templates"))
+env = Environment(
+    loader=FileSystemLoader("docker_templates"), trim_blocks=False, lstrip_blocks=False
+)
 
 headers = {
     "User-Agent": "Adoptium Dockerfile Updater",


### PR DESCRIPTION
For all new versions (JDK25+) we won't ship build-time packages.