### PR TITLE
Update Dependabot ignore for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
   schedule:
     interval: daily
   ignore:
-    - dependency-name: "github/gh-aw-actions/setup"
+    - dependency-name: "github/gh-aw-actions"
   open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot is auto bumping the AW workflow which is breaking the Docker Summary report