### PR TITLE
Add version-specific architecture overrides

### DIFF
--- a/17/jdk/ubuntu/resolute/Dockerfile
+++ b/17/jdk/ubuntu/resolute/Dockerfile
@@ -72,10 +72,6 @@ RUN set -eux; \
          ESUM='c9d8dc52960ff00aa8c321e211cc5284a2151cffdedeac998f5297066cbad245'; \
          BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.19_10.tar.gz'; \
          ;; \
-       riscv64) \
-         ESUM='191cdd904aef8b8a7a91c98d649c7e3dc75b7341f112061231c2094c418fd630'; \
-         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_riscv64_linux_hotspot_17.0.19_10.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='00363a5ceda57aa0dee89d20b3f6b2966e3c1f3fb6dcf57e66d2264573d3c63e'; \
          BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.19_10.tar.gz'; \

--- a/17/jre/ubuntu/resolute/Dockerfile
+++ b/17/jre/ubuntu/resolute/Dockerfile
@@ -69,10 +69,6 @@ RUN set -eux; \
          ESUM='1b028a08d96054ef29a3b6c424537d9644e0ec5fb5742a64d967dd56d5571b6b'; \
          BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.19_10.tar.gz'; \
          ;; \
-       riscv64) \
-         ESUM='08c8c193fc2e8e6eb4450d3ddcefa78889eef338b2bbc0b30e5a6d586fc6d646'; \
-         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_riscv64_linux_hotspot_17.0.19_10.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='674547d46dad6909fdcdafe5a691c131b048a8d226ccd7d0a4e96f2b208d772a'; \
          BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_s390x_linux_hotspot_17.0.19_10.tar.gz'; \

--- a/21/jdk/ubuntu/resolute/Dockerfile
+++ b/21/jdk/ubuntu/resolute/Dockerfile
@@ -68,10 +68,6 @@ RUN set -eux; \
          ESUM='3d043ae96d2343962bf2307d8c55f19849fbfa4c6be9fe164a77d79263f0d989'; \
          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.11_10.tar.gz'; \
          ;; \
-       riscv64) \
-         ESUM='40c6862e6aff63fe9a03856ba0506531b516a17bdb5018464e9006ea7f0f5fe4'; \
-         BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.11_10.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='14dbe3cb226e64b945a36bea32686e8deec746504fe3ccee8de585c54af41ffd'; \
          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_s390x_linux_hotspot_21.0.11_10.tar.gz'; \

--- a/21/jre/ubuntu/resolute/Dockerfile
+++ b/21/jre/ubuntu/resolute/Dockerfile
@@ -65,10 +65,6 @@ RUN set -eux; \
          ESUM='fefb53c4bd687e7a91a9a9809ec80e0862e829cd20513839ad1a9988ddc89482'; \
          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_ppc64le_linux_hotspot_21.0.11_10.tar.gz'; \
          ;; \
-       riscv64) \
-         ESUM='f3d8843c5a1b77ded3353e0df85d803d84b9faa5ece20673564e7c47fc4591d9'; \
-         BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_riscv64_linux_hotspot_21.0.11_10.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='45736e9e14d52619133900a077b4f72d1ebee0fd0bb053da0bca9dce9fc4d916'; \
          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_s390x_linux_hotspot_21.0.11_10.tar.gz'; \

--- a/25/jdk/ubuntu/resolute/Dockerfile
+++ b/25/jdk/ubuntu/resolute/Dockerfile
@@ -63,10 +63,6 @@ RUN set -eux; \
          ESUM='72b0fbb201716ca465ab704ec0fb12971abab3fdde5ae8d03b125a273522cf05'; \
          BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_ppc64le_linux_hotspot_25.0.3_9.tar.gz'; \
          ;; \
-       riscv64) \
-         ESUM='3b23af7f7dfe82e1dc66509cb825d82d08372f2e7f66ae85a7fdb42a4c84bfcc'; \
-         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_riscv64_linux_hotspot_25.0.3_9.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='24b497d10acb6ee706ca30e1c8a929785c250cad54c5c12f1f8f93c3c06a53f7'; \
          BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_s390x_linux_hotspot_25.0.3_9.tar.gz'; \

--- a/25/jre/ubuntu/resolute/Dockerfile
+++ b/25/jre/ubuntu/resolute/Dockerfile
@@ -60,10 +60,6 @@ RUN set -eux; \
          ESUM='82daf66b73505d3974d831bd244acbb1123a340b7752ced449dcdca69ff3a780'; \
          BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_ppc64le_linux_hotspot_25.0.3_9.tar.gz'; \
          ;; \
-       riscv64) \
-         ESUM='8325460857162b85050622962cee64cbc441ca9baf07f93a7535fd3f9962ca33'; \
-         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_riscv64_linux_hotspot_25.0.3_9.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='ee513969bef35f10afb7d06840d9a421138a3d30c062cde3dda8fe780dc451a2'; \
          BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_s390x_linux_hotspot_25.0.3_9.tar.gz'; \

--- a/26/jdk/ubuntu/resolute/Dockerfile
+++ b/26/jdk/ubuntu/resolute/Dockerfile
@@ -63,10 +63,6 @@ RUN set -eux; \
          ESUM='60e016faf4177840430035d948f83f2887d556fe512b78c1d43b320322fe6685'; \
          BINARY_URL='https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_ppc64le_linux_hotspot_26.0.1_8.tar.gz'; \
          ;; \
-       riscv64) \
-         ESUM='f1b762d6d86599627983df200f215bc970444a697159ca3fae93208756b44715'; \
-         BINARY_URL='https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_riscv64_linux_hotspot_26.0.1_8.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='942de7ded1427592a2a4b6dbea4083b2d0891de2626c7863e970de3e2819a93f'; \
          BINARY_URL='https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_s390x_linux_hotspot_26.0.1_8.tar.gz'; \

--- a/26/jre/ubuntu/resolute/Dockerfile
+++ b/26/jre/ubuntu/resolute/Dockerfile
@@ -60,10 +60,6 @@ RUN set -eux; \
          ESUM='d8f66903603c3661c0d8c03de41b76459260ed2e295ba874bb7b3f37a012c026'; \
          BINARY_URL='https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_ppc64le_linux_hotspot_26.0.1_8.tar.gz'; \
          ;; \
-       riscv64) \
-         ESUM='277d00ea87cf0ec0ede6736007b2fb44432fac754613df4649e61f385beb55f0'; \
-         BINARY_URL='https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_riscv64_linux_hotspot_26.0.1_8.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='3c68d7df7d64a7738a6bd97b12fb2167774666d87bf9a309094bb2180073eb38'; \
          BINARY_URL='https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_s390x_linux_hotspot_26.0.1_8.tar.gz'; \

--- a/config/temurin.yml
+++ b/config/temurin.yml
@@ -12,24 +12,38 @@
 # limitations under the License.
 #
 
+architecture_overrides:
+  # We don't ship s390x for JDK8 as it has no JIT
+  - versions: "==8"
+    exclude: [s390x]
+  # We only ship riscv64 for JDK17 and above
+  - versions: "<17"
+    exclude: [riscv64]
+  # We don't ship arm32 for JDK21 and above
+  - versions: ">=21"
+    exclude: [arm]
+
 configurations:
   linux:
   # EOL April 2031
   - directory: ubuntu/resolute
     image: ubuntu:26.04
-    architectures: [aarch64, arm, ppc64le, riscv64, s390x, x64]
+    # TODO add riscv64 back once upstream docker can build it
+    architectures: [aarch64, arm, ppc64le, s390x, x64]
     os: ubuntu
 
   # EOL April 2029
   - directory: ubuntu/noble
     image: ubuntu:24.04
     architectures: [aarch64, arm, ppc64le, riscv64, s390x, x64]
+    deprecated: 27
     os: ubuntu
   
   # EOL April 2027
   - directory: ubuntu/jammy
     image: ubuntu:22.04
     architectures: [aarch64, arm, ppc64le, s390x, x64]
+    deprecated: 27
     os: ubuntu
 
   # EOL May 2035

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -28,24 +28,6 @@ from adoptium_api import get_supported_versions
 
 requests_cache.install_cache("adoptium_cache", expire_after=3600)
 
-parser = argparse.ArgumentParser(
-    description="Generate Dockerfiles for Eclipse Temurin images"
-)
-
-# Setup the Jinja2 environment
-env = Environment(
-    loader=FileSystemLoader("docker_templates"), trim_blocks=False, lstrip_blocks=False
-)
-
-headers = {
-    "User-Agent": "Adoptium Dockerfile Updater",
-}
-
-# Flag for force removing old Dockerfiles
-parser.add_argument("--force", action="store_true", help="Force remove old Dockerfiles")
-
-args = parser.parse_args()
-
 
 VERSION_OPERATORS = {
     "==": operator.eq,
@@ -105,153 +87,172 @@ def archHelper(arch, os_name):
         return arch
 
 
-# Remove old Dockerfiles if --force is set
-if args.force:
-    # Remove all top level dirs that are numbers
-    for dir in os.listdir():
-        if dir.isdigit():
-            print(f"Removing {dir}")
-            shutil.rmtree(dir)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate Dockerfiles for Eclipse Temurin images"
+    )
+
+    # Setup the Jinja2 environment
+    env = Environment(
+        loader=FileSystemLoader("docker_templates"), trim_blocks=False, lstrip_blocks=False
+    )
+
+    headers = {
+        "User-Agent": "Adoptium Dockerfile Updater",
+    }
+
+    # Flag for force removing old Dockerfiles
+    parser.add_argument("--force", action="store_true", help="Force remove old Dockerfiles")
+
+    args = parser.parse_args()
+
+    # Remove old Dockerfiles if --force is set
+    if args.force:
+        # Remove all top level dirs that are numbers
+        for dir in os.listdir():
+            if dir.isdigit():
+                print(f"Removing {dir}")
+                shutil.rmtree(dir)
 
 
-# Load the YAML configuration
-with open("config/temurin.yml", "r") as file:
-    config = yaml.safe_load(file)
+    # Load the YAML configuration
+    with open("config/temurin.yml", "r") as file:
+        config = yaml.safe_load(file)
 
-# Global architecture overrides apply to all configurations
-global_architecture_overrides = config.get("architecture_overrides", [])
+    # Global architecture overrides apply to all configurations
+    global_architecture_overrides = config.get("architecture_overrides", [])
 
-# Fetch supported versions from the Adoptium API
-supported_versions = get_supported_versions()
+    # Fetch supported versions from the Adoptium API
+    supported_versions = get_supported_versions()
 
-# Iterate through OS families and then configurations
-for os_family, configurations in config["configurations"].items():
-    for configuration in configurations:
-        directory = configuration["directory"]
-        default_architectures = configuration["architectures"]
-        local_overrides = configuration.get("architecture_overrides", [])
-        architecture_overrides = global_architecture_overrides + local_overrides
-        os_name = configuration["os"]
-        base_image = configuration["image"]
-        deprecated = configuration.get("deprecated", None)
-        versions = configuration.get("versions", supported_versions)
+    # Iterate through OS families and then configurations
+    for os_family, configurations in config["configurations"].items():
+        for configuration in configurations:
+            directory = configuration["directory"]
+            default_architectures = configuration["architectures"]
+            local_overrides = configuration.get("architecture_overrides", [])
+            architecture_overrides = global_architecture_overrides + local_overrides
+            os_name = configuration["os"]
+            base_image = configuration["image"]
+            deprecated = configuration.get("deprecated", None)
+            versions = configuration.get("versions", supported_versions)
 
-        # Define the path for the template based on OS
-        template_name = f"{os_name}.Dockerfile.j2"
-        template = env.get_template(template_name)
+            # Define the path for the template based on OS
+            template_name = f"{os_name}.Dockerfile.j2"
+            template = env.get_template(template_name)
 
-        # Create output directories if they don't exist
-        for version in versions:
-            # if deprecated is set and version is greater than or equal to deprecated, skip
-            if deprecated and version >= deprecated:
-                continue
-
-            architectures = resolve_architectures(default_architectures, architecture_overrides, version)
-            print("Generating Dockerfiles for", base_image, "-", version)
-            for image_type in ["jdk", "jre"]:
-                output_directory = os.path.join(str(version), image_type, directory)
-                os.makedirs(output_directory, exist_ok=True)
-
-                # Fetch latest release for version from Adoptium API
-                url = f"https://api.adoptium.net/v3/assets/feature_releases/{version}/ga?page=0&image_type={image_type}&os={os_family}&page_size=1&vendor=eclipse"
-                response = requests.get(url, headers=headers)
-
-                # Handle 404 errors gracefully - skip this version if not available
-                if response.status_code == 404:
-                    print(f"Version {version} not available for {image_type} on {os_family}, skipping...")
+            # Create output directories if they don't exist
+            for version in versions:
+                # if deprecated is set and version is greater than or equal to deprecated, skip
+                if deprecated and version >= deprecated:
                     continue
 
-                response.raise_for_status()
-                data = response.json()
+                architectures = resolve_architectures(default_architectures, architecture_overrides, version)
+                print("Generating Dockerfiles for", base_image, "-", version)
+                for image_type in ["jdk", "jre"]:
+                    output_directory = os.path.join(str(version), image_type, directory)
+                    os.makedirs(output_directory, exist_ok=True)
 
-                release = response.json()[0]
+                    # Fetch latest release for version from Adoptium API
+                    url = f"https://api.adoptium.net/v3/assets/feature_releases/{version}/ga?page=0&image_type={image_type}&os={os_family}&page_size=1&vendor=eclipse"
+                    response = requests.get(url, headers=headers)
 
-                # Extract the version number from the release name
-                openjdk_version = release["release_name"]
-
-                # If version doesn't equal 8, get the more accurate version number
-                if version != 8:
-                    openjdk_version = (
-                        "jdk-" + release["version_data"]["openjdk_version"]
-                    )
-                    # if openjdk_version contains -LTS remove it
-                    if "-LTS" in openjdk_version:
-                        openjdk_version = openjdk_version.replace("-LTS", "")
-
-                # Generate the data for each architecture
-                arch_data = {}
-
-                for binary in release["binaries"]:
-                    if (
-                        binary["architecture"] in architectures
-                        and binary["os"] == os_family
-                    ):
-                        if os_family == "windows":
-                            # Windows only has x64 binaries
-                            copy_from = openjdk_version.replace(
-                                "jdk", ""
-                            )  # jdk8u292-b10 -> 8u292-b10
-                            if version != 8:
-                                copy_from = copy_from.replace("-", "").replace(
-                                    "+", "_"
-                                )  # 11.0.11+9 -> 11.0.11_9
-                            copy_from = f"{copy_from}-{image_type}-windowsservercore-{base_image.split(':')[1]}"
-                            arch_data = {
-                                "download_url": binary["installer"]["link"],
-                                "checksum": binary["installer"]["checksum"],
-                                "copy_from": copy_from,
-                            }
-                        else:
-                            arch_data[archHelper(binary["architecture"], os_name)] = {
-                                "download_url": binary["package"]["link"],
-                                "checksum": binary["package"]["checksum"],
-                            }
-
-                    else:
+                    # Handle 404 errors gracefully - skip this version if not available
+                    if response.status_code == 404:
+                        print(f"Version {version} not available for {image_type} on {os_family}, skipping...")
                         continue
 
-                # If arch_data is empty, skip updating the dockerfile
-                if arch_data.__len__() == 0:
-                    continue
+                    response.raise_for_status()
+                    data = response.json()
 
-                # Sort arch_data by key
-                arch_data = dict(sorted(arch_data.items()))
+                    release = response.json()[0]
 
-                # Generate Dockerfile for each architecture
-                rendered_dockerfile = template.render(
-                    base_image=base_image,
-                    image_type=image_type,
-                    java_version=openjdk_version,
-                    version=version,
-                    arch_data=arch_data,
-                    os_family=os_family,
-                    os=os_name,
-                )
+                    # Extract the version number from the release name
+                    openjdk_version = release["release_name"]
 
-                print("Writing Dockerfile to", output_directory)
-                # Save the rendered Dockerfile
-                with open(
-                    os.path.join(output_directory, "Dockerfile"), "w"
-                ) as out_file:
-                    out_file.write(rendered_dockerfile)
+                    # If version doesn't equal 8, get the more accurate version number
+                    if version != 8:
+                        openjdk_version = (
+                            "jdk-" + release["version_data"]["openjdk_version"]
+                        )
+                        # if openjdk_version contains -LTS remove it
+                        if "-LTS" in openjdk_version:
+                            openjdk_version = openjdk_version.replace("-LTS", "")
 
-                if os_family != "windows":
-                    # Entrypoint is currently only needed for CA certificate handling, which is not (yet)
-                    # available on Windows
+                    # Generate the data for each architecture
+                    arch_data = {}
 
-                    # Generate entrypoint.sh
-                    template_entrypoint_file = "entrypoint.sh.j2"
-                    template_entrypoint = env.get_template(template_entrypoint_file)
+                    for binary in release["binaries"]:
+                        if (
+                            binary["architecture"] in architectures
+                            and binary["os"] == os_family
+                        ):
+                            if os_family == "windows":
+                                # Windows only has x64 binaries
+                                copy_from = openjdk_version.replace(
+                                    "jdk", ""
+                                )  # jdk8u292-b10 -> 8u292-b10
+                                if version != 8:
+                                    copy_from = copy_from.replace("-", "").replace(
+                                        "+", "_"
+                                    )  # 11.0.11+9 -> 11.0.11_9
+                                copy_from = f"{copy_from}-{image_type}-windowsservercore-{base_image.split(':')[1]}"
+                                arch_data = {
+                                    "download_url": binary["installer"]["link"],
+                                    "checksum": binary["installer"]["checksum"],
+                                    "copy_from": copy_from,
+                                }
+                            else:
+                                arch_data[archHelper(binary["architecture"], os_name)] = {
+                                    "download_url": binary["package"]["link"],
+                                    "checksum": binary["package"]["checksum"],
+                                }
 
-                    entrypoint = template_entrypoint.render(
+                        else:
+                            continue
+
+                    # If arch_data is empty, skip updating the dockerfile
+                    if arch_data.__len__() == 0:
+                        continue
+
+                    # Sort arch_data by key
+                    arch_data = dict(sorted(arch_data.items()))
+
+                    # Generate Dockerfile for each architecture
+                    rendered_dockerfile = template.render(
+                        base_image=base_image,
                         image_type=image_type,
-                        os=os_name,
+                        java_version=openjdk_version,
                         version=version,
+                        arch_data=arch_data,
+                        os_family=os_family,
+                        os=os_name,
                     )
 
+                    print("Writing Dockerfile to", output_directory)
+                    # Save the rendered Dockerfile
                     with open(
-                        os.path.join(output_directory, "entrypoint.sh"), "w"
+                        os.path.join(output_directory, "Dockerfile"), "w"
                     ) as out_file:
-                        out_file.write(entrypoint)
+                        out_file.write(rendered_dockerfile)
 
-print("Dockerfiles generated successfully!")
+                    if os_family != "windows":
+                        # Entrypoint is currently only needed for CA certificate handling, which is not (yet)
+                        # available on Windows
+
+                        # Generate entrypoint.sh
+                        template_entrypoint_file = "entrypoint.sh.j2"
+                        template_entrypoint = env.get_template(template_entrypoint_file)
+
+                        entrypoint = template_entrypoint.render(
+                            image_type=image_type,
+                            os=os_name,
+                            version=version,
+                        )
+
+                        with open(
+                            os.path.join(output_directory, "entrypoint.sh"), "w"
+                        ) as out_file:
+                            out_file.write(entrypoint)
+
+    print("Dockerfiles generated successfully!")

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -14,7 +14,9 @@
 #
 
 import argparse
+import operator
 import os
+import re
 import shutil
 
 import requests
@@ -43,6 +45,48 @@ headers = {
 parser.add_argument("--force", action="store_true", help="Force remove old Dockerfiles")
 
 args = parser.parse_args()
+
+
+VERSION_OPERATORS = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    "<=": operator.le,
+    ">": operator.gt,
+    "<": operator.lt,
+}
+
+VERSION_CONDITION_RE = re.compile(r"^(==|!=|>=|<=|>|<)(\d+)$")
+
+
+def resolve_architectures(default_architectures, overrides, version):
+    """Resolve effective architectures for a given version by applying overrides.
+
+    All matching overrides are applied in order. Each override has a 'versions'
+    string (e.g. '==8', '<=11', '>17') and either:
+      - 'exclude': list of architectures to remove
+      - 'include': list of architectures to add
+      - 'architectures': full replacement list (overrides default entirely)
+    """
+    if not overrides:
+        return default_architectures
+
+    result = list(default_architectures)
+    for override in overrides:
+        condition = override["versions"].strip()
+        match = VERSION_CONDITION_RE.match(condition)
+        if not match:
+            raise ValueError(f"Invalid version condition: '{condition}'")
+        op_str, target = match.groups()
+        if VERSION_OPERATORS[op_str](version, int(target)):
+            if "architectures" in override:
+                result = list(override["architectures"])
+            if "exclude" in override:
+                result = [a for a in result if a not in override["exclude"]]
+            if "include" in override:
+                result = result + [a for a in override["include"] if a not in result]
+
+    return result
 
 
 def archHelper(arch, os_name):
@@ -74,6 +118,9 @@ if args.force:
 with open("config/temurin.yml", "r") as file:
     config = yaml.safe_load(file)
 
+# Global architecture overrides apply to all configurations
+global_architecture_overrides = config.get("architecture_overrides", [])
+
 # Fetch supported versions from the Adoptium API
 supported_versions = get_supported_versions()
 
@@ -81,7 +128,9 @@ supported_versions = get_supported_versions()
 for os_family, configurations in config["configurations"].items():
     for configuration in configurations:
         directory = configuration["directory"]
-        architectures = configuration["architectures"]
+        default_architectures = configuration["architectures"]
+        local_overrides = configuration.get("architecture_overrides", [])
+        architecture_overrides = global_architecture_overrides + local_overrides
         os_name = configuration["os"]
         base_image = configuration["image"]
         deprecated = configuration.get("deprecated", None)
@@ -96,6 +145,8 @@ for os_family, configurations in config["configurations"].items():
             # if deprecated is set and version is greater than or equal to deprecated, skip
             if deprecated and version >= deprecated:
                 continue
+
+            architectures = resolve_architectures(default_architectures, architecture_overrides, version)
             print("Generating Dockerfiles for", base_image, "-", version)
             for image_type in ["jdk", "jre"]:
                 output_directory = os.path.join(str(version), image_type, directory)

--- a/test_generate_dockerfiles.py
+++ b/test_generate_dockerfiles.py
@@ -16,6 +16,8 @@ from unittest.mock import Mock, mock_open, patch
 
 from jinja2 import Environment, FileSystemLoader
 
+from generate_dockerfiles import resolve_architectures
+
 
 class TestJinjaRendering(unittest.TestCase):
     def setUp(self):
@@ -231,6 +233,83 @@ class TestJinjaRendering(unittest.TestCase):
         # Ensure that the entrypoint script contains expected commands
         self.assertIn("update-ca-certificates", rendered_template)
         self.assertIn("exec \"$@\"", rendered_template)
+
+
+class TestResolveArchitectures(unittest.TestCase):
+    def setUp(self):
+        self.default_archs = ["aarch64", "arm", "ppc64le", "s390x", "x64"]
+
+    def test_no_overrides_returns_default(self):
+        result = resolve_architectures(self.default_archs, None, 17)
+        self.assertEqual(result, self.default_archs)
+
+    def test_empty_overrides_returns_default(self):
+        result = resolve_architectures(self.default_archs, [], 17)
+        self.assertEqual(result, self.default_archs)
+
+    def test_exact_match_full_replacement(self):
+        overrides = [{"versions": "==8", "architectures": ["aarch64", "x64"]}]
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 8), ["aarch64", "x64"])
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 11), self.default_archs)
+
+    def test_exclude(self):
+        overrides = [{"versions": ">=21", "exclude": ["arm"]}]
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 21), ["aarch64", "ppc64le", "s390x", "x64"])
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 17), self.default_archs)
+
+    def test_include(self):
+        overrides = [{"versions": ">=17", "include": ["riscv64"]}]
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 17), ["aarch64", "arm", "ppc64le", "s390x", "x64", "riscv64"])
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 11), self.default_archs)
+
+    def test_include_no_duplicates(self):
+        overrides = [{"versions": ">=17", "include": ["x64", "riscv64"]}]
+        result = resolve_architectures(self.default_archs, overrides, 17)
+        self.assertEqual(result.count("x64"), 1)
+        self.assertIn("riscv64", result)
+
+    def test_multiple_matching_overrides_applied(self):
+        overrides = [
+            {"versions": ">=21", "exclude": ["arm"]},
+            {"versions": "<17", "exclude": ["riscv64"]},
+        ]
+        # version 8 matches only second rule
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 8), ["aarch64", "arm", "ppc64le", "s390x", "x64"])
+        # version 17 matches neither
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 17), self.default_archs)
+        # version 21 matches only first rule
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 21), ["aarch64", "ppc64le", "s390x", "x64"])
+
+    def test_all_matching_overrides_accumulate(self):
+        overrides = [
+            {"versions": "==8", "exclude": ["s390x"]},
+            {"versions": "<17", "exclude": ["riscv64"]},
+        ]
+        # version 8 matches both rules
+        result = resolve_architectures(["aarch64", "arm", "ppc64le", "riscv64", "s390x", "x64"], overrides, 8)
+        self.assertNotIn("s390x", result)
+        self.assertNotIn("riscv64", result)
+        self.assertEqual(result, ["aarch64", "arm", "ppc64le", "x64"])
+
+    def test_not_equal(self):
+        overrides = [{"versions": "!=8", "exclude": ["arm"]}]
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 11), ["aarch64", "ppc64le", "s390x", "x64"])
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 8), self.default_archs)
+
+    def test_less_than(self):
+        overrides = [{"versions": "<11", "exclude": ["s390x"]}]
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 8), ["aarch64", "arm", "ppc64le", "x64"])
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 11), self.default_archs)
+
+    def test_greater_than(self):
+        overrides = [{"versions": ">17", "exclude": ["arm"]}]
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 21), ["aarch64", "ppc64le", "s390x", "x64"])
+        self.assertEqual(resolve_architectures(self.default_archs, overrides, 17), self.default_archs)
+
+    def test_invalid_condition_raises(self):
+        overrides = [{"versions": "~8", "exclude": ["x64"]}]
+        with self.assertRaises(ValueError):
+            resolve_architectures(self.default_archs, overrides, 8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `architecture_overrides` support to `temurin.yml` and `generate_dockerfiles.py` to allow excluding (or including) architectures based on JDK version constraints.

## Motivation

Certain architectures are not available for all JDK versions:
- **s390x** is not shipped for JDK 8 (no JIT)
- **riscv64** is only available for JDK 17+
- **arm32** is not available for JDK 21+

Previously, the architecture list per distro config had no way to express these version-specific constraints, leading to incorrect Dockerfiles or manual workarounds.

## Changes

- **`config/temurin.yml`**: Added a top-level `architecture_overrides` section with global rules that apply to all configurations. Per-config overrides are also supported.
- **`generate_dockerfiles.py`**: Added `resolve_architectures()` function that evaluates version conditions (`==`, `!=`, `>=`, `<=`, `>`, `<`) and applies `exclude`/`include`/full `architectures` replacement. All matching overrides accumulate in order.
- **`test_generate_dockerfiles.py`**: Added comprehensive tests for the override resolution logic.
- **Regenerated Dockerfiles** for ubuntu/resolute to reflect the riscv64 TODO.

## Override format

```yaml
architecture_overrides:
  - versions: "==8"
    exclude: [s390x]
  - versions: "<17"
    exclude: [riscv64]
  - versions: ">=21"
    exclude: [arm]
```