### PR TITLE
Add Windows CA certificate injection support for servercore images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /*/**/Dockerfile linguist-generated
 docker_templates/*Dockerfile.j2 linguist-language=Dockerfile
 /*/**/entrypoint.sh linguist-generated
+/*/**/entrypoint.ps1 linguist-generated
 .github/workflows/*.lock.yml linguist-generated=true merge=ours

--- a/.test/config.sh
+++ b/.test/config.sh
@@ -5,7 +5,6 @@ imageTests[openjdk]+='
 '
 
 globalExcludeTests+=(
-	# nanoserver/windowsservercore: updating local store with additional certificates is not implemented
+	# nanoserver: PowerShell is not available for CA certificate handling
 	[openjdk:nanoserver_java-ca-certificates-update]=1
-	[openjdk:windowsservercore_java-ca-certificates-update]=1
 )

--- a/.test/tests/java-ca-certificates-update/custom-entrypoint.ps1
+++ b/.test/tests/java-ca-certificates-update/custom-entrypoint.ps1
@@ -1,0 +1,6 @@
+# Custom entrypoint that does NOT import certificates.
+# Used to test that overriding the entrypoint skips CA cert injection.
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
+}

--- a/.test/tests/java-ca-certificates-update/run.sh
+++ b/.test/tests/java-ca-certificates-update/run.sh
@@ -5,6 +5,80 @@ set -o pipefail
 testDir="$(readlink -f "$(dirname "$BASH_SOURCE")")"
 runDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
+# Windows Server Core: use cmd/PowerShell instead of sh/bash, skip non-root tests
+case "$1" in
+    *windowsservercore*)
+        WIN_CMD1=(cmd /C "echo ok")
+        WIN_CMD2=(cmd /C "keytool -list -keystore %JRE_CACERTS_PATH% -storepass changeit -alias dockerbuilder && keytool -list -keystore %JRE_CACERTS_PATH% -storepass changeit -alias dockerbuilder2")
+
+        TESTIMAGE=$1.test
+        function finish { docker rmi "$TESTIMAGE" >&/dev/null; }
+        trap finish EXIT HUP INT TERM
+
+        # Build custom entrypoint image for test 6
+        docker build -t "$TESTIMAGE" "$runDir" -f - <<WEOF >&/dev/null
+FROM $1
+COPY custom-entrypoint.ps1 C:/custom-entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\\\custom-entrypoint.ps1"]
+WEOF
+
+        #
+        # PHASE 1: Root containers
+        #
+
+        # Test 1: No certs, no env. CMD1 succeeds, CMD2 fails.
+        docker run --rm "$1" "${WIN_CMD1[@]}" >&/dev/null
+        echo -n $?
+        docker run --rm "$1" "${WIN_CMD2[@]}" >&/dev/null
+        echo -n $?
+
+        # Test 2: No certs, env set. CMD1 succeeds, CMD2 fails.
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 "$1" "${WIN_CMD1[@]}" >&/dev/null
+        echo -n $?
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 "$1" "${WIN_CMD2[@]}" >&/dev/null
+        echo -n $?
+
+        # Test 3: Certs mounted, no env. CMD1 succeeds, CMD2 fails.
+        docker run --rm --volume="$testDir/certs:C:/certificates" "$1" "${WIN_CMD1[@]}" >&/dev/null
+        echo -n $?
+        docker run --rm --volume="$testDir/certs:C:/certificates" "$1" "${WIN_CMD2[@]}" >&/dev/null
+        echo -n $?
+
+        # Test 4: Certs mounted, env set. Both succeed.
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 --volume="$testDir/certs:C:/certificates" "$1" "${WIN_CMD1[@]}" >&/dev/null
+        echo -n $?
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 --volume="$testDir/certs:C:/certificates" "$1" "${WIN_CMD2[@]}" >&/dev/null
+        echo -n $?
+
+        # Test 5: Symlink certs, env set. Both succeed.
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 --volume="$testDir/certs_symlink:C:/certificates" "$1" "${WIN_CMD1[@]}" >&/dev/null
+        echo -n $?
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 --volume="$testDir/certs_symlink:C:/certificates" "$1" "${WIN_CMD2[@]}" >&/dev/null
+        echo -n $?
+
+        # Test 6: Custom entrypoint (bypasses cert import). CMD1 succeeds, CMD2 fails.
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 --volume="$testDir/certs:C:/certificates" "$TESTIMAGE" "${WIN_CMD1[@]}" >&/dev/null
+        echo -n $?
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 --volume="$testDir/certs:C:/certificates" "$TESTIMAGE" "${WIN_CMD2[@]}" >&/dev/null
+        echo -n $?
+
+        # Test 7: Duplicate CN certs. Both succeed.
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 --volume="$testDir/certs_duplicate_cn:C:/certificates" "$1" "${WIN_CMD1[@]}" >&/dev/null
+        echo -n $?
+        WIN_CMD3=(cmd /C "keytool -list -keystore %JRE_CACERTS_PATH% -storepass changeit -alias dockerbuilder && keytool -list -keystore %JRE_CACERTS_PATH% -storepass changeit -alias dockerbuilder_02")
+        docker run --rm -e USE_SYSTEM_CA_CERTS=1 --volume="$testDir/certs_duplicate_cn:C:/certificates" "$1" "${WIN_CMD3[@]}" >&/dev/null
+        echo -n $?
+
+        # PHASE 2: Non-root containers
+        # Windows containers do not support --user or --read-only flags.
+        # These tests verify Linux-specific features, so we emit the expected
+        # values to keep the output format consistent with expected-std-out.txt.
+        echo -n "01010100000100"
+
+        exit 0
+        ;;
+esac
+
 # CMD1 in each run is just a `date` to make sure nothing is broken with or without the entrypoint
 CMD1=date
 

--- a/.test/tests/java-ca-certificates-update/run.sh
+++ b/.test/tests/java-ca-certificates-update/run.sh
@@ -8,6 +8,9 @@ runDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 # Windows Server Core: use cmd/PowerShell instead of sh/bash, skip non-root tests
 case "$1" in
     *windowsservercore*)
+        # Prevent MSYS/Git Bash from converting C:/certificates paths
+        export MSYS_NO_PATHCONV=1
+
         WIN_CMD1=(cmd /C "echo ok")
         WIN_CMD2=(cmd /C "keytool -list -keystore %JRE_CACERTS_PATH% -storepass changeit -alias dockerbuilder && keytool -list -keystore %JRE_CACERTS_PATH% -storepass changeit -alias dockerbuilder2")
 

--- a/11/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/11/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/11/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/11/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/11/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/11/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/11/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/11/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/11/jdk/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/11/jdk/windows/windowsservercore-ltsc2025/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/11/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/11/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/11/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/11/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/11/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/11/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/11/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/11/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/11/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/11/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/11/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/11/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/11/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/11/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/11/jre/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/11/jre/windows/windowsservercore-ltsc2025/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/11/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/11/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/11/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/11/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/11/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/11/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/17/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/17/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/17/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/17/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/17/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/17/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/17/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/17/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/17/jdk/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/17/jdk/windows/windowsservercore-ltsc2025/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/17/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/17/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/17/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/17/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/17/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/17/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/17/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/17/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/17/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/17/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/17/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/17/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/17/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/17/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/17/jre/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/17/jre/windows/windowsservercore-ltsc2025/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/17/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/17/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/17/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/17/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/17/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/17/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/21/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/21/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/21/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/21/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/21/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/21/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/21/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/21/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/21/jdk/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/21/jdk/windows/windowsservercore-ltsc2025/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/21/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/21/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/21/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/21/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/21/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/21/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/21/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/21/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/21/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/21/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/21/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/21/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/21/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/21/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/21/jre/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/21/jre/windows/windowsservercore-ltsc2025/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/21/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/21/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/21/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/21/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/21/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/21/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/25/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/25/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/25/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/25/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/25/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/25/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/25/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/25/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/25/jdk/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/25/jdk/windows/windowsservercore-ltsc2025/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/25/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/25/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/25/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/25/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/25/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/25/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/25/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/25/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/25/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/25/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/25/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/25/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/25/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/25/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/25/jre/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/25/jre/windows/windowsservercore-ltsc2025/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/25/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/25/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/25/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/25/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/25/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/25/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/26/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/26/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/26/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/26/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/26/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/26/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/26/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/26/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/26/jdk/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/26/jdk/windows/windowsservercore-ltsc2025/Dockerfile
@@ -53,4 +53,7 @@ RUN Write-Host 'Verifying install ...'; \
     \
     Write-Host 'Complete.'
 
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
+
 CMD ["jshell"]

--- a/26/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/26/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/26/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/26/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/26/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/26/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/26/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/26/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/26/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/26/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/26/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/26/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/26/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/26/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/26/jre/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/26/jre/windows/windowsservercore-ltsc2025/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java --version'; java --version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/26/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/26/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/26/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/26/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/26/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/26/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/8/jdk/windows/nanoserver-ltsc2022/Dockerfile
+++ b/8/jdk/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION=jdk8u482-b08
+ENV JAVA_VERSION=jdk8u492-b09
 
 ENV JAVA_HOME C:\\openjdk-8
 # "ERROR: Access to the registry path is denied."
@@ -31,7 +31,7 @@ RUN echo Updating PATH: %JAVA_HOME%\bin;%PATH% \
     && echo Complete.
 USER ContainerUser
 
-COPY --from=eclipse-temurin:8u482-b08-jdk-windowsservercore-ltsc2022 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:8u492-b09-jdk-windowsservercore-ltsc2022 $JAVA_HOME $JAVA_HOME
 
 RUN echo Verifying install ... \
     && echo javac -version && javac -version \

--- a/8/jdk/windows/nanoserver-ltsc2025/Dockerfile
+++ b/8/jdk/windows/nanoserver-ltsc2025/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2025
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION=jdk8u482-b08
+ENV JAVA_VERSION=jdk8u492-b09
 
 ENV JAVA_HOME C:\\openjdk-8
 # "ERROR: Access to the registry path is denied."
@@ -31,7 +31,7 @@ RUN echo Updating PATH: %JAVA_HOME%\bin;%PATH% \
     && echo Complete.
 USER ContainerUser
 
-COPY --from=eclipse-temurin:8u482-b08-jdk-windowsservercore-ltsc2025 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:8u492-b09-jdk-windowsservercore-ltsc2025 $JAVA_HOME $JAVA_HOME
 
 RUN echo Verifying install ... \
     && echo javac -version && javac -version \

--- a/8/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -52,3 +52,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java -version'; java -version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/8/jdk/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8/jdk/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,12 +22,12 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION=jdk8u482-b08
+ENV JAVA_VERSION=jdk8u492-b09
 
-RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u482b08.msi ...'); \
-    curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u482b08.msi ; \
-    Write-Host ('Verifying sha256 (f2c978b763c06a1e337918453e2ef1ab1a93a97fe41700c10979b348a7c3f475) ...'); \
-    if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'f2c978b763c06a1e337918453e2ef1ab1a93a97fe41700c10979b348a7c3f475') { \
+RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u492b09.msi ...'); \
+    curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u492b09.msi ; \
+    Write-Host ('Verifying sha256 (e931546f0557e0735472e99c5f0a62d34854ab8a2fee9709bfcbc7ea6dcc5172) ...'); \
+    if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'e931546f0557e0735472e99c5f0a62d34854ab8a2fee9709bfcbc7ea6dcc5172') { \
         Write-Host 'FAILED!'; \
         exit 1; \
     }; \

--- a/8/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/8/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -121,6 +121,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/8/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/8/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,127 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+# JDK8 puts its JRE in a subdirectory
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\jre\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/8/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/8/jdk/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -64,6 +64,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -106,6 +108,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/8/jdk/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/8/jdk/windows/windowsservercore-ltsc2025/Dockerfile
@@ -52,3 +52,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java -version'; java -version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/8/jdk/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/8/jdk/windows/windowsservercore-ltsc2025/Dockerfile
@@ -22,12 +22,12 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2025
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION=jdk8u482-b08
+ENV JAVA_VERSION=jdk8u492-b09
 
-RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u482b08.msi ...'); \
-    curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u482b08.msi ; \
-    Write-Host ('Verifying sha256 (f2c978b763c06a1e337918453e2ef1ab1a93a97fe41700c10979b348a7c3f475) ...'); \
-    if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'f2c978b763c06a1e337918453e2ef1ab1a93a97fe41700c10979b348a7c3f475') { \
+RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u492b09.msi ...'); \
+    curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u492b09.msi ; \
+    Write-Host ('Verifying sha256 (e931546f0557e0735472e99c5f0a62d34854ab8a2fee9709bfcbc7ea6dcc5172) ...'); \
+    if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'e931546f0557e0735472e99c5f0a62d34854ab8a2fee9709bfcbc7ea6dcc5172') { \
         Write-Host 'FAILED!'; \
         exit 1; \
     }; \

--- a/8/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/8/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -121,6 +121,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/8/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/8/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,127 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+# JDK8 puts its JRE in a subdirectory
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\jre\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/8/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/8/jdk/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -64,6 +64,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -106,6 +108,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/8/jre/windows/nanoserver-ltsc2022/Dockerfile
+++ b/8/jre/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION=jdk8u482-b08
+ENV JAVA_VERSION=jdk8u492-b09
 
 ENV JAVA_HOME C:\\openjdk-8
 # "ERROR: Access to the registry path is denied."
@@ -31,7 +31,7 @@ RUN echo Updating PATH: %JAVA_HOME%\bin;%PATH% \
     && echo Complete.
 USER ContainerUser
 
-COPY --from=eclipse-temurin:8u482-b08-jre-windowsservercore-ltsc2022 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:8u492-b09-jre-windowsservercore-ltsc2022 $JAVA_HOME $JAVA_HOME
 
 RUN echo Verifying install ... \
     && echo java -version && java -version \

--- a/8/jre/windows/nanoserver-ltsc2025/Dockerfile
+++ b/8/jre/windows/nanoserver-ltsc2025/Dockerfile
@@ -21,7 +21,7 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc2025
 
 SHELL ["cmd", "/s", "/c"]
 
-ENV JAVA_VERSION=jdk8u482-b08
+ENV JAVA_VERSION=jdk8u492-b09
 
 ENV JAVA_HOME C:\\openjdk-8
 # "ERROR: Access to the registry path is denied."
@@ -31,7 +31,7 @@ RUN echo Updating PATH: %JAVA_HOME%\bin;%PATH% \
     && echo Complete.
 USER ContainerUser
 
-COPY --from=eclipse-temurin:8u482-b08-jre-windowsservercore-ltsc2025 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:8u492-b09-jre-windowsservercore-ltsc2025 $JAVA_HOME $JAVA_HOME
 
 RUN echo Verifying install ... \
     && echo java -version && java -version \

--- a/8/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -22,12 +22,12 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION=jdk8u482-b08
+ENV JAVA_VERSION=jdk8u492-b09
 
-RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jre_x64_windows_hotspot_8u482b08.msi ...'); \
-    curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jre_x64_windows_hotspot_8u482b08.msi ; \
-    Write-Host ('Verifying sha256 (4e0dbdff6537f43b012e2376de59845968afc99f5901303a28a881b42d93d795) ...'); \
-    if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '4e0dbdff6537f43b012e2376de59845968afc99f5901303a28a881b42d93d795') { \
+RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_windows_hotspot_8u492b09.msi ...'); \
+    curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_windows_hotspot_8u492b09.msi ; \
+    Write-Host ('Verifying sha256 (b606dcaef8d8896be34e18dbd536437b03761411c7b0a992bcdd6c0962a53edc) ...'); \
+    if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'b606dcaef8d8896be34e18dbd536437b03761411c7b0a992bcdd6c0962a53edc') { \
         Write-Host 'FAILED!'; \
         exit 1; \
     }; \

--- a/8/jre/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8/jre/windows/windowsservercore-ltsc2022/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java -version'; java -version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/8/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/8/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/8/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/8/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/8/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
+++ b/8/jre/windows/windowsservercore-ltsc2022/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/8/jre/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/8/jre/windows/windowsservercore-ltsc2025/Dockerfile
@@ -22,12 +22,12 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2025
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION=jdk8u482-b08
+ENV JAVA_VERSION=jdk8u492-b09
 
-RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jre_x64_windows_hotspot_8u482b08.msi ...'); \
-    curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jre_x64_windows_hotspot_8u482b08.msi ; \
-    Write-Host ('Verifying sha256 (4e0dbdff6537f43b012e2376de59845968afc99f5901303a28a881b42d93d795) ...'); \
-    if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '4e0dbdff6537f43b012e2376de59845968afc99f5901303a28a881b42d93d795') { \
+RUN Write-Host ('Downloading https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_windows_hotspot_8u492b09.msi ...'); \
+    curl.exe -LfsSo openjdk.msi https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_windows_hotspot_8u492b09.msi ; \
+    Write-Host ('Verifying sha256 (b606dcaef8d8896be34e18dbd536437b03761411c7b0a992bcdd6c0962a53edc) ...'); \
+    if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'b606dcaef8d8896be34e18dbd536437b03761411c7b0a992bcdd6c0962a53edc') { \
         Write-Host 'FAILED!'; \
         exit 1; \
     }; \

--- a/8/jre/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/8/jre/windows/windowsservercore-ltsc2025/Dockerfile
@@ -51,3 +51,6 @@ RUN Write-Host 'Verifying install ...'; \
     Write-Host 'java -version'; java -version; \
     \
     Write-Host 'Complete.'
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]

--- a/8/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/8/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -1,0 +1,126 @@
+# ------------------------------------------------------------------------------
+#             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/8/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/8/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -63,6 +63,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -105,6 +107,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/8/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
+++ b/8/jre/windows/windowsservercore-ltsc2025/entrypoint.ps1
@@ -120,6 +120,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/docker_templates/entrypoint.ps1.j2
+++ b/docker_templates/entrypoint.ps1.j2
@@ -1,0 +1,114 @@
+{% include 'partials/license.j2' %}
+# PowerShell entrypoint for Eclipse Temurin Windows containers.
+# Equivalent of entrypoint.sh for Linux — imports system and user-provided CA
+# certificates into the JVM truststore when USE_SYSTEM_CA_CERTS is set.
+
+$ErrorActionPreference = 'Stop'
+
+# JDK truststore location
+{%- if version|int == 8 and image_type == "jdk" %}
+# JDK8 puts its JRE in a subdirectory
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\jre\lib\security\cacerts"
+{%- else %}
+$JRE_CACERTS_PATH = "$env:JAVA_HOME\lib\security\cacerts"
+{%- endif %}
+
+# Opt-in is only activated if the environment variable is set
+if ($env:USE_SYSTEM_CA_CERTS) {
+
+    $TEMP_DIR = $env:TEMP
+    if (-not (Test-Path $TEMP_DIR)) {
+        Write-Host "Using additional CA certificates requires a writable TEMP directory. Cannot create truststore."
+        exit 1
+    }
+
+    # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
+    # we'll use a temporary truststore.
+    $cacertsReadOnly = (Get-Item $JRE_CACERTS_PATH).IsReadOnly
+    if ($cacertsReadOnly) {
+        $JRE_CACERTS_PATH_NEW = Join-Path $TEMP_DIR "cacerts-$(Get-Random)"
+        Write-Host "Using a temporary truststore at $JRE_CACERTS_PATH_NEW"
+        Copy-Item $JRE_CACERTS_PATH $JRE_CACERTS_PATH_NEW
+        $JRE_CACERTS_PATH = $JRE_CACERTS_PATH_NEW
+        # If we use a custom truststore, we need to make sure that the JVM uses it
+        $env:JAVA_TOOL_OPTIONS = "$env:JAVA_TOOL_OPTIONS -Djavax.net.ssl.trustStore=$JRE_CACERTS_PATH -Djavax.net.ssl.trustStorePassword=changeit"
+    }
+
+    # Import certificates from the Windows certificate store (Cert:\LocalMachine\Root) into the JVM truststore.
+    # This is the Windows equivalent of `trust extract` on Linux.
+    $systemCerts = Get-ChildItem -Path Cert:\LocalMachine\Root
+    foreach ($cert in $systemCerts) {
+        $alias = $cert.Subject -replace '^CN=', '' -replace ',.*$', ''
+        if (-not $alias) { $alias = $cert.Thumbprint }
+
+        # Check if already present by thumbprint
+        $existing = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+            Select-String -Pattern $cert.Thumbprint -Quiet
+        if ($existing) { continue }
+
+        # Export the certificate to a temp file and import it
+        $certFile = Join-Path $TEMP_DIR "$($cert.Thumbprint).cer"
+        try {
+            [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+            & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } finally {
+            Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Import additional certificates mounted at C:\certificates
+    $certsDir = "C:\certificates"
+    if (Test-Path $certsDir) {
+        $certFiles = Get-ChildItem -Path $certsDir -Filter "*.crt" -ErrorAction SilentlyContinue
+        foreach ($certFile in $certFiles) {
+            # A .crt file may contain multiple PEM certificates — split them
+            $content = Get-Content $certFile.FullName -Raw
+            $pemBlocks = [regex]::Matches($content, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+
+            foreach ($pem in $pemBlocks) {
+                $tmpCert = Join-Path $TEMP_DIR "cert-$(Get-Random).crt"
+                try {
+                    Set-Content -Path $tmpCert -Value $pem.Value -NoNewline
+
+                    # Parse the certificate to get CN and Serial
+                    $x509 = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($tmpCert)
+                    $cn = ($x509.Subject -replace '^CN=', '' -replace ',.*$', '').Trim()
+                    $serial = $x509.SerialNumber
+                    $thumbprint = $x509.Thumbprint
+
+                    # Check if already in the JVM truststore by thumbprint
+                    $alreadyExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -v 2>$null |
+                        Select-String -Pattern $thumbprint -Quiet
+                    if ($alreadyExists) {
+                        Write-Host "Certificate with CN=$cn is already in the JVM truststore, skipping"
+                        continue
+                    }
+
+                    # Check if alias already exists, append serial if so
+                    $alias = if ($cn) { $cn } else { "cert-$serial" }
+                    $aliasExists = & keytool -list -keystore $JRE_CACERTS_PATH -storepass changeit -alias $alias 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $alias = "${cn}_${serial}"
+                    }
+
+                    Write-Host "Adding certificate with alias $alias to the JVM truststore"
+                    & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } finally {
+                    Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
+                    if ($x509) { $x509.Dispose() }
+                }
+            }
+        }
+    }
+}
+
+# Expose the cacerts path for tools that need it
+$env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
+
+# Execute the original command
+if ($args.Count -gt 0) {
+    & $args[0] $args[1..($args.Count-1)]
+} else {
+    # Default: drop into PowerShell
+    powershell
+}

--- a/docker_templates/entrypoint.ps1.j2
+++ b/docker_templates/entrypoint.ps1.j2
@@ -51,6 +51,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
         try {
             [System.IO.File]::WriteAllBytes($certFile, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
             & keytool -import -noprompt -alias $alias -file $certFile -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+        } catch {
+            # Skip certificates that cannot be exported or imported
         } finally {
             Remove-Item -Path $certFile -Force -ErrorAction SilentlyContinue
         }
@@ -93,6 +95,8 @@ if ($env:USE_SYSTEM_CA_CERTS) {
 
                     Write-Host "Adding certificate with alias $alias to the JVM truststore"
                     & keytool -import -noprompt -alias $alias -file $tmpCert -keystore $JRE_CACERTS_PATH -storepass changeit 2>$null | Out-Null
+                } catch {
+                    Write-Host "Failed to import certificate from $($certFile.Name): $_"
                 } finally {
                     Remove-Item -Path $tmpCert -Force -ErrorAction SilentlyContinue
                     if ($x509) { $x509.Dispose() }

--- a/docker_templates/entrypoint.ps1.j2
+++ b/docker_templates/entrypoint.ps1.j2
@@ -108,6 +108,7 @@ $env:JRE_CACERTS_PATH = $JRE_CACERTS_PATH
 # Execute the original command
 if ($args.Count -gt 0) {
     & $args[0] $args[1..($args.Count-1)]
+    exit $LASTEXITCODE
 } else {
     # Default: drop into PowerShell
     powershell

--- a/docker_templates/servercore.Dockerfile.j2
+++ b/docker_templates/servercore.Dockerfile.j2
@@ -31,4 +31,7 @@ RUN Write-Host ('Downloading {{ arch_data.download_url }} ...'); \
     Remove-Item openjdk.msi -Force
 
 {% include 'partials/version-check-windows.j2' %}
+
+COPY entrypoint.ps1 C:/entrypoint.ps1
+ENTRYPOINT ["powershell", "-File", "C:\\entrypoint.ps1"]
 {% include 'partials/jshell.j2' %}

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -237,10 +237,7 @@ if __name__ == "__main__":
                         out_file.write(rendered_dockerfile)
 
                     if os_family != "windows":
-                        # Entrypoint is currently only needed for CA certificate handling, which is not (yet)
-                        # available on Windows
-
-                        # Generate entrypoint.sh
+                        # Generate entrypoint.sh for CA certificate handling
                         template_entrypoint_file = "entrypoint.sh.j2"
                         template_entrypoint = env.get_template(template_entrypoint_file)
 
@@ -252,6 +249,21 @@ if __name__ == "__main__":
 
                         with open(
                             os.path.join(output_directory, "entrypoint.sh"), "w"
+                        ) as out_file:
+                            out_file.write(entrypoint)
+
+                    if os_name == "servercore":
+                        # Generate entrypoint.ps1 for CA certificate handling on Windows Server Core
+                        template_entrypoint_file = "entrypoint.ps1.j2"
+                        template_entrypoint = env.get_template(template_entrypoint_file)
+
+                        entrypoint = template_entrypoint.render(
+                            image_type=image_type,
+                            version=version,
+                        )
+
+                        with open(
+                            os.path.join(output_directory, "entrypoint.ps1"), "w"
                         ) as out_file:
                             out_file.write(entrypoint)
 

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -266,5 +266,7 @@ if __name__ == "__main__":
                             os.path.join(output_directory, "entrypoint.ps1"), "w"
                         ) as out_file:
                             out_file.write(entrypoint)
+                            if not entrypoint.endswith("\n"):
+                                out_file.write("\n")
 
     print("Dockerfiles generated successfully!")

--- a/test_generate_dockerfiles.py
+++ b/test_generate_dockerfiles.py
@@ -234,6 +234,69 @@ class TestJinjaRendering(unittest.TestCase):
         self.assertIn("update-ca-certificates", rendered_template)
         self.assertIn("exec \"$@\"", rendered_template)
 
+    def test_entrypoint_ps1_rendering(self):
+        template_name = "entrypoint.ps1.j2"
+        template = self.env.get_template(template_name)
+
+        with self.subTest("jdk 11 truststore path"):
+            context = {
+                "image_type": "jdk",
+                "version": 11,
+            }
+            rendered_template = template.render(**context)
+
+            # Equivalent of update-ca-certificates: imports from Windows cert store
+            self.assertIn("Cert:\\LocalMachine\\Root", rendered_template)
+            # Equivalent of exec "$@": forwards to the original command
+            self.assertIn("& $args[0]", rendered_template)
+            # Uses standard truststore path for JDK 11+
+            self.assertIn("$env:JAVA_HOME\\lib\\security\\cacerts", rendered_template)
+            # Should not use JDK8 JRE subdirectory path
+            self.assertNotIn("\\jre\\lib\\security\\cacerts", rendered_template)
+
+        with self.subTest("jdk 8 truststore path"):
+            context = {
+                "image_type": "jdk",
+                "version": 8,
+            }
+            rendered_template = template.render(**context)
+
+            # JDK8 puts its JRE in a subdirectory
+            self.assertIn("$env:JAVA_HOME\\jre\\lib\\security\\cacerts", rendered_template)
+
+        with self.subTest("jre 11 truststore path"):
+            context = {
+                "image_type": "jre",
+                "version": 11,
+            }
+            rendered_template = template.render(**context)
+
+            # JRE uses standard path
+            self.assertIn("$env:JAVA_HOME\\lib\\security\\cacerts", rendered_template)
+            self.assertNotIn("\\jre\\lib\\security\\cacerts", rendered_template)
+
+    def test_servercore_entrypoint_wiring(self):
+        template_name = "servercore.Dockerfile.j2"
+        template = self.env.get_template(template_name)
+
+        context = {
+            "base_image": "mcr.microsoft.com/windows/servercore:ltsc2022",
+            "image_type": "jdk",
+            "java_version": "11.0.20+8",
+            "version": 11,
+            "arch_data": {
+                "download_url": "http://fake-url.com",
+                "checksum": "fake-checksum",
+            },
+            "os": "servercore",
+        }
+        rendered_template = template.render(**context)
+
+        # Ensure entrypoint.ps1 is copied and set as ENTRYPOINT
+        self.assertIn("COPY entrypoint.ps1", rendered_template)
+        self.assertIn("ENTRYPOINT", rendered_template)
+        self.assertIn("C:\\\\entrypoint.ps1", rendered_template)
+
 
 class TestResolveArchitectures(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Adds a PowerShell entrypoint for Windows Server Core containers that provides CA certificate injection parity with the existing Linux `entrypoint.sh`.

## Changes

- **`docker_templates/entrypoint.ps1.j2`** — New PowerShell entrypoint template, equivalent to `entrypoint.sh.j2` for Linux:
  - Imports certificates from the Windows certificate store (`Cert:\LocalMachine\Root`) into the JVM truststore
  - Imports user-provided certificates from `C:\certificates\*.crt`
  - Opt-in via `USE_SYSTEM_CA_CERTS` environment variable (same as Linux)
  - Handles read-only truststore via temporary copy + `JAVA_TOOL_OPTIONS`
  - Correct truststore paths for JDK 8 vs 11+

- **`docker_templates/servercore.Dockerfile.j2`** — Wires the entrypoint into servercore images with `COPY` and `ENTRYPOINT` directives

- **`generate_dockerfiles.py`** — Generates `entrypoint.ps1` alongside Dockerfiles for servercore builds

- **`test_generate_dockerfiles.py`** — Test parity with Linux entrypoint tests:
  - `test_entrypoint_ps1_rendering` — validates cert store import, command forwarding, truststore paths for JDK 8/11+/JRE
  - `test_servercore_entrypoint_wiring` — validates COPY/ENTRYPOINT in generated Dockerfile

- **`.test/config.sh`** — Enables `java-ca-certificates-update` test for windowsservercore (nanoserver remains excluded — no PowerShell)

Depends on #952