### PR TITLE
Use keytool -cacerts on JDK 9+ in cacert entrypoint.

### DIFF
--- a/docker_templates/entrypoint.sh.j2
+++ b/docker_templates/entrypoint.sh.j2
@@ -28,6 +28,22 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         exit 1
     fi
 
+    # Wrap keytool truststore access. JDK 9+ uses -cacerts (added in JDK 9)
+    # to avoid the "Warning: use -cacerts option to access cacerts keystore"
+    # that keytool emits when -keystore points at the default cacerts file.
+    # JDK 8 has no -cacerts and uses -keystore. The temporary-truststore
+    # branch below rebinds the JDK 9+ wrapper to -keystore as well, since
+    # -cacerts would still resolve to the read-only default. -importkeystore
+    # is not routed through this wrapper: its -destkeystore/-srckeystore do
+    # not trigger the warning and have no -cacerts form.
+    keytool_truststore() {
+{%- if version|int >= 9 %}
+        keytool -cacerts "$@"
+{%- else %}
+        keytool -keystore "$JRE_CACERTS_PATH" "$@"
+{%- endif %}
+    }
+
     # Figure out whether we can write to the JVM truststore. If we can, we'll add the certificates there. If not,
     # we'll use a temporary truststore.
     if [ ! -w "$JRE_CACERTS_PATH" ]; then
@@ -38,6 +54,12 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         JRE_CACERTS_PATH=$JRE_CACERTS_PATH_NEW
         # If we use a custom truststore, we need to make sure that the JVM uses it
         export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djavax.net.ssl.trustStore=${JRE_CACERTS_PATH} -Djavax.net.ssl.trustStorePassword=changeit"
+{%- if version|int >= 9 %}
+        # Rebind: -cacerts would still resolve to the read-only default.
+        keytool_truststore() {
+            keytool -keystore "$JRE_CACERTS_PATH" "$@"
+        }
+{%- endif %}
     fi
 
     tmp_store=$(mktemp)
@@ -72,14 +94,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
             # failures on container restart when the certificate was added to the system CA store in a
             # previous run and is now being re-imported via keytool -importkeystore.
             FINGERPRINT=$(openssl x509 -in "$crt" -noout -fingerprint -sha256 2>/dev/null | cut -d'=' -f2)
-            if [ -n "$FINGERPRINT" ] && keytool -list -keystore "$JRE_CACERTS_PATH" -storepass changeit -v 2>/dev/null | grep -qiF "$FINGERPRINT"; then
+            if [ -n "$FINGERPRINT" ] && keytool_truststore -list -storepass changeit -v 2>/dev/null | grep -qiF "$FINGERPRINT"; then
                 echo "Certificate with CN=$CN is already in the JVM truststore, skipping"
                 continue
             fi
 
             # Check if an alias with the CN already exists in the keystore
             ALIAS=$CN
-            if keytool -list -keystore "$JRE_CACERTS_PATH" -storepass changeit -alias "$ALIAS" >/dev/null 2>&1; then
+            if keytool_truststore -list -storepass changeit -alias "$ALIAS" >/dev/null 2>&1; then
                 # If the CN already exists, append the serial number to the alias
                 ALIAS="${CN}_${SERIAL}"
             fi
@@ -87,7 +109,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
             echo "Adding certificate with alias $ALIAS to the JVM truststore"
 
             # Add the certificate to the JVM truststore
-            keytool -import -noprompt -alias "$ALIAS" -file "$crt" -keystore "$JRE_CACERTS_PATH" -storepass changeit >/dev/null
+            keytool_truststore -import -noprompt -alias "$ALIAS" -file "$crt" -storepass changeit >/dev/null
         done
     done
 


### PR DESCRIPTION
On JDK 9+, keytool emits "Warning: use -cacerts option to access cacerts keystore" whenever -keystore is given the path of the JDK's default cacerts file. The __cacert_entrypoint.sh script passes -keystore "$JRE_CACERTS_PATH" to keytool's -list and -import subcommands, so every container start under USE_SYSTEM_CA_CERTS=1 produces the warning at least once per imported certificate.

Wrap keytool's truststore access in a small shell function that uses the -cacerts flag on JDK 9+ (added in JDK 9 via JDK-8162739, the documented way to address the default cacerts file) and falls back to -keystore in two cases: on JDK 8 (where -cacerts does not exist), and on the temporary-truststore branch the script takes when the JDK default is read-only (where -cacerts would still resolve to the read-only default rather than the writable temporary file). keytool's -importkeystore is not routed through the wrapper because -destkeystore and -srckeystore do not trigger the warning and have no -cacerts equivalent.

Verified against eclipse-temurin:25-jdk: the deprecation warning count drops from one (or more) per processed cert to 0 in both the writable and the read-only-fallback container modes; java -version still works in both modes; shellcheck is clean across all 89 regenerated entrypoint.sh files (ubuntu/bash, alpine/sh, ubi-minimal/sh, every JDK version); test_generate_dockerfiles, test_dockerhub_doc_config_update, and sanity.sh all pass.

This change was drafted with the assistance of Claude (Anthropic's claude-opus-4-7 model). The committer reviewed every line, verified the JDK source (sun.security.tools.keytool.Main.parseArgs) for the exact warning trigger, and ran the empirical verification matrix described above.