### PR TITLE
Add EOL checker using endoflife.date API

### DIFF
--- a/.github/workflows/check-eol.yml
+++ b/.github/workflows/check-eol.yml
@@ -1,0 +1,92 @@
+name: Check EOL Distros
+
+on:
+  schedule:
+    # Run every Monday at 09:00 UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-eol:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Check for expired distros
+        id: eol-check
+        run: |
+          python -c "
+          import yaml, json, sys
+          from eol_checker import check_eol_configs
+
+          with open('config/temurin.yml') as f:
+              config = yaml.safe_load(f)
+
+          expired = check_eol_configs(config)
+          if not expired:
+              print('No expired distros found.')
+              sys.exit(0)
+
+          print(f'Found {len(expired)} expired distro(s):')
+          body_lines = ['## Expired Distro Report', '', 'The following base images are past their EOL date and should be removed:', '']
+          for cfg, eol_date in expired:
+              image = cfg.get('image', cfg.get('directory', 'unknown'))
+              directory = cfg.get('directory', '')
+              line = f'- **{image}** (\`{directory}\`) — EOL {eol_date}'
+              print(f'  {image} ({directory}) expired {eol_date}')
+              body_lines.append(line)
+
+          body_lines.append('')
+          body_lines.append('Please remove these configurations and their generated Dockerfiles.')
+
+          with open('eol_report.json', 'w') as f:
+              json.dump({'title': f'🗑️ {len(expired)} distro(s) past EOL', 'body': chr(10).join(body_lines)}, f)
+          "
+
+      - name: Create issue for expired distros
+        if: hashFiles('eol_report.json') != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('eol_report.json', 'utf8'));
+
+            // Check if an open issue already exists
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'eol-cleanup',
+            });
+
+            if (issues.data.length > 0) {
+              // Update existing issue
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues.data[0].number,
+                body: report.body,
+              });
+              console.log(`Updated existing issue #${issues.data[0].number}`);
+            } else {
+              // Create new issue
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: report.title,
+                body: report.body,
+                labels: ['eol-cleanup'],
+              });
+              console.log('Created new EOL cleanup issue');
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,10 @@ on:
     paths:
       - adoptium_api.py
       - dockerhub_doc_config_update.py
+      - eol_checker.py
       - generate_dockerfiles.py
       - test_dockerhub_doc_config_update.py
+      - test_eol_checker.py
       - test_generate_dockerfiles.py
       - requirements.txt
     branches: [ main ]
@@ -27,6 +29,4 @@ jobs:
         run: "pip3 install -r requirements.txt"
 
       - name: Run tests
-        run: |
-          python3 -m unittest test_generate_dockerfiles -v
-          python3 -m unittest test_dockerhub_doc_config_update -v
+        run: python3 -m unittest discover -v -p 'test_*.py'

--- a/config/temurin.yml
+++ b/config/temurin.yml
@@ -25,34 +25,29 @@ architecture_overrides:
 
 configurations:
   linux:
-  # EOL April 2031
   - directory: ubuntu/resolute
     image: ubuntu:26.04
     # TODO add riscv64 back once upstream docker can build it
     architectures: [aarch64, arm, ppc64le, s390x, x64]
     os: ubuntu
 
-  # EOL April 2029
   - directory: ubuntu/noble
     image: ubuntu:24.04
     architectures: [aarch64, arm, ppc64le, riscv64, s390x, x64]
     deprecated: 27
     os: ubuntu
-  
-  # EOL April 2027
+
   - directory: ubuntu/jammy
     image: ubuntu:22.04
     architectures: [aarch64, arm, ppc64le, s390x, x64]
     deprecated: 27
     os: ubuntu
 
-  # EOL May 2035
   - directory: ubi/ubi10-minimal
     architectures: [aarch64, ppc64le, s390x, x64]
     image: redhat/ubi10-minimal
     os: ubi-minimal
 
-  # EOL May 2032
   - directory: ubi/ubi9-minimal
     architectures: [aarch64, ppc64le, s390x, x64]
     image: redhat/ubi9-minimal
@@ -60,27 +55,23 @@ configurations:
     os: ubi-minimal
 
   alpine-linux:
-  # EOL 01 June 2028
   - directory: alpine/3.24
     architectures: [aarch64, x64]
     image: alpine:3.24
     os: alpine-linux
 
-  # EOL 01 Nov 2027
   - directory: alpine/3.23
     architectures: [aarch64, x64]
     image: alpine:3.23
     deprecated: 27
     os: alpine-linux
 
-  # EOL 01 May 2027
   - directory: alpine/3.22
     architectures: [aarch64, x64]
     image: alpine:3.22
     deprecated: 26
     os: alpine-linux
 
-  # EOL 01 Nov 2026
   - directory: alpine/3.21
     architectures: [aarch64, x64]
     image: alpine:3.21

--- a/dockerhub_doc_config_update.py
+++ b/dockerhub_doc_config_update.py
@@ -29,6 +29,7 @@ import urllib.request
 import yaml
 
 from adoptium_api import get_latest_lts, get_supported_versions
+from eol_checker import print_eol_warnings
 
 OFFICIAL_MANIFEST_URL = (
     "https://raw.githubusercontent.com/docker-library/official-images/"
@@ -310,6 +311,7 @@ def generate_manifest(config, output_file):
 def main():
     output_file = sys.argv[1] if len(sys.argv) > 1 else "eclipse-temurin"
     config = load_config()
+    print_eol_warnings(config)
     generate_manifest(config, output_file)
 
 

--- a/eol_checker.py
+++ b/eol_checker.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Fetch EOL dates from endoflife.date API for base images."""
+
+import re
+import sys
+import urllib.request
+import json
+from datetime import date, datetime
+
+ENDOFLIFE_API = "https://endoflife.date/api"
+
+# Map os config values to endoflife.date product names
+OS_TO_PRODUCT = {
+    "ubuntu": "ubuntu",
+    "alpine-linux": "alpine",
+    "ubi-minimal": "rhel",
+}
+
+# Regex to extract version from image string (e.g. "ubuntu:26.04" -> "26.04",
+# "redhat/ubi9-minimal" -> "9", "alpine:3.24" -> "3.24")
+IMAGE_VERSION_PATTERNS = [
+    # standard image:tag format
+    re.compile(r":(\d[\d.]*)$"),
+    # UBI images like redhat/ubi9-minimal -> extract major version
+    re.compile(r"/ubi(\d+)"),
+]
+
+
+def _extract_cycle(image):
+    """Extract the version/cycle string from a Docker image reference."""
+    for pattern in IMAGE_VERSION_PATTERNS:
+        m = pattern.search(image)
+        if m:
+            return m.group(1)
+    return None
+
+
+def fetch_eol_date(product, cycle):
+    """Fetch the EOL date for a product cycle from endoflife.date.
+
+    Returns a date object or None if the lookup fails.
+    """
+    url = f"{ENDOFLIFE_API}/{product}/{cycle}.json"
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "Adoptium EOL Checker"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            eol = data.get("eol")
+            if isinstance(eol, bool):
+                # Some products return eol: false (meaning not yet EOL)
+                return None
+            if eol:
+                return datetime.strptime(eol, "%Y-%m-%d").date()
+    except Exception:
+        pass
+    return None
+
+
+def get_eol_date(configuration):
+    """Get the EOL date for a configuration entry.
+
+    Priority:
+    1. Hardcoded 'eol' field in the config (as fallback/override)
+    2. Lookup from endoflife.date API based on os + image
+    """
+    # Check for hardcoded override first
+    eol_str = configuration.get("eol")
+    if eol_str:
+        if isinstance(eol_str, date):
+            return eol_str
+        return datetime.strptime(str(eol_str), "%Y-%m-%d").date()
+
+    os_name = configuration.get("os", "")
+    image = configuration.get("image", "")
+
+    product = OS_TO_PRODUCT.get(os_name)
+    if not product:
+        return None
+
+    cycle = _extract_cycle(image)
+    if not cycle:
+        return None
+
+    return fetch_eol_date(product, cycle)
+
+
+def check_eol_configs(config):
+    """Check all configurations for EOL status.
+
+    Returns a list of (configuration, eol_date) tuples for entries past EOL.
+    """
+    today = date.today()
+    expired = []
+
+    for os_family, configurations in config.get("configurations", {}).items():
+        for cfg in configurations:
+            eol_date = get_eol_date(cfg)
+            if eol_date and eol_date <= today:
+                expired.append((cfg, eol_date))
+
+    return expired
+
+
+def print_eol_warnings(config, file=sys.stderr):
+    """Print warnings for any expired distros. Returns the list of expired entries."""
+    expired = check_eol_configs(config)
+    if expired:
+        print(f"\n⚠ {len(expired)} distro(s) past EOL:", file=file)
+        for cfg, eol_date in expired:
+            image = cfg.get("image", cfg.get("directory", "unknown"))
+            directory = cfg.get("directory", "")
+            print(f"  - {image} ({directory}) expired {eol_date}", file=file)
+    return expired
+
+
+if __name__ == "__main__":
+    import yaml
+
+    with open("config/temurin.yml") as f:
+        config = yaml.safe_load(f)
+
+    print("Distro EOL dates:")
+    for os_family, configurations in config.get("configurations", {}).items():
+        for cfg in configurations:
+            image = cfg.get("image", cfg.get("directory", "unknown"))
+            eol = get_eol_date(cfg)
+            eol_str = str(eol) if eol else "unknown"
+            print(f"  {image}: {eol_str}")
+
+    print()
+    expired = print_eol_warnings(config, file=sys.stdout)
+    if not expired:
+        print("All distros are within their EOL dates.")
+    sys.exit(1 if expired else 0)

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -18,6 +18,7 @@ import operator
 import os
 import re
 import shutil
+import sys
 
 import requests
 import requests_cache
@@ -25,6 +26,7 @@ import yaml
 from jinja2 import Environment, FileSystemLoader
 
 from adoptium_api import get_supported_versions
+from eol_checker import print_eol_warnings
 
 requests_cache.install_cache("adoptium_cache", expire_after=3600)
 
@@ -126,6 +128,9 @@ if __name__ == "__main__":
     supported_versions = get_supported_versions()
 
     # Iterate through OS families and then configurations
+    # Check for expired distros
+    print_eol_warnings(config)
+
     for os_family, configurations in config["configurations"].items():
         for configuration in configurations:
             directory = configuration["directory"]

--- a/test_eol_checker.py
+++ b/test_eol_checker.py
@@ -1,0 +1,188 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import unittest
+from datetime import date
+from unittest.mock import patch, MagicMock
+
+from eol_checker import (
+    OS_TO_PRODUCT,
+    _extract_cycle,
+    check_eol_configs,
+    fetch_eol_date,
+    get_eol_date,
+)
+
+
+def _mock_urlopen(response_data):
+    """Create a mock for urllib.request.urlopen that returns JSON data."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(response_data).encode("utf-8")
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestExtractCycle(unittest.TestCase):
+
+    def test_ubuntu_image(self):
+        self.assertEqual(_extract_cycle("ubuntu:26.04"), "26.04")
+
+    def test_alpine_image(self):
+        self.assertEqual(_extract_cycle("alpine:3.21"), "3.21")
+
+    def test_ubi_image(self):
+        self.assertEqual(_extract_cycle("redhat/ubi9-minimal"), "9")
+
+    def test_ubi10_image(self):
+        self.assertEqual(_extract_cycle("redhat/ubi10-minimal"), "10")
+
+    def test_no_version(self):
+        self.assertIsNone(_extract_cycle("scratch"))
+
+    def test_windows_image(self):
+        # Windows images use non-numeric tags like ltsc2022
+        self.assertIsNone(_extract_cycle("mcr.microsoft.com/windows/servercore:ltsc2022"))
+
+
+class TestFetchEolDate(unittest.TestCase):
+
+    @patch("eol_checker.urllib.request.urlopen")
+    def test_returns_date(self, mock_urlopen_fn):
+        mock_urlopen_fn.return_value = _mock_urlopen({"eol": "2027-11-01"})
+        result = fetch_eol_date("alpine", "3.23")
+        self.assertEqual(result, date(2027, 11, 1))
+
+    @patch("eol_checker.urllib.request.urlopen")
+    def test_returns_none_for_bool_eol(self, mock_urlopen_fn):
+        mock_urlopen_fn.return_value = _mock_urlopen({"eol": False})
+        result = fetch_eol_date("alpine", "99.99")
+        self.assertIsNone(result)
+
+    @patch("eol_checker.urllib.request.urlopen")
+    def test_returns_none_on_network_error(self, mock_urlopen_fn):
+        mock_urlopen_fn.side_effect = Exception("network error")
+        result = fetch_eol_date("alpine", "3.21")
+        self.assertIsNone(result)
+
+
+class TestGetEolDate(unittest.TestCase):
+
+    @patch("eol_checker.fetch_eol_date", return_value=date(2027, 11, 1))
+    def test_fetches_from_api(self, mock_fetch):
+        cfg = {"os": "alpine-linux", "image": "alpine:3.23"}
+        result = get_eol_date(cfg)
+        self.assertEqual(result, date(2027, 11, 1))
+        mock_fetch.assert_called_once_with("alpine", "3.23")
+
+    @patch("eol_checker.fetch_eol_date", return_value=date(2029, 4, 30))
+    def test_ubuntu(self, mock_fetch):
+        cfg = {"os": "ubuntu", "image": "ubuntu:24.04"}
+        result = get_eol_date(cfg)
+        self.assertEqual(result, date(2029, 4, 30))
+        mock_fetch.assert_called_once_with("ubuntu", "24.04")
+
+    @patch("eol_checker.fetch_eol_date", return_value=date(2032, 5, 31))
+    def test_ubi(self, mock_fetch):
+        cfg = {"os": "ubi-minimal", "image": "redhat/ubi9-minimal"}
+        result = get_eol_date(cfg)
+        self.assertEqual(result, date(2032, 5, 31))
+        mock_fetch.assert_called_once_with("rhel", "9")
+
+    def test_hardcoded_eol_takes_priority(self):
+        cfg = {"os": "ubuntu", "image": "ubuntu:24.04", "eol": "2030-01-01"}
+        result = get_eol_date(cfg)
+        self.assertEqual(result, date(2030, 1, 1))
+
+    def test_hardcoded_eol_as_date_object(self):
+        cfg = {"os": "ubuntu", "image": "ubuntu:24.04", "eol": date(2030, 1, 1)}
+        result = get_eol_date(cfg)
+        self.assertEqual(result, date(2030, 1, 1))
+
+    def test_unknown_os_returns_none(self):
+        cfg = {"os": "servercore", "image": "mcr.microsoft.com/windows/servercore:ltsc2022"}
+        result = get_eol_date(cfg)
+        self.assertIsNone(result)
+
+
+class TestCheckEolConfigs(unittest.TestCase):
+
+    @patch("eol_checker.get_eol_date")
+    def test_finds_expired(self, mock_get_eol):
+        mock_get_eol.side_effect = [date(2020, 1, 1), date(2099, 1, 1)]
+        config = {
+            "configurations": {
+                "linux": [
+                    {"os": "ubuntu", "image": "ubuntu:20.04", "directory": "ubuntu/focal"},
+                    {"os": "ubuntu", "image": "ubuntu:24.04", "directory": "ubuntu/noble"},
+                ],
+            }
+        }
+        expired = check_eol_configs(config)
+        self.assertEqual(len(expired), 1)
+        self.assertEqual(expired[0][0]["directory"], "ubuntu/focal")
+        self.assertEqual(expired[0][1], date(2020, 1, 1))
+
+    @patch("eol_checker.get_eol_date", return_value=None)
+    def test_skips_when_no_eol(self, mock_get_eol):
+        config = {
+            "configurations": {
+                "windows": [
+                    {"os": "servercore", "image": "mcr.microsoft.com/windows/servercore:ltsc2022"},
+                ],
+            }
+        }
+        expired = check_eol_configs(config)
+        self.assertEqual(len(expired), 0)
+
+
+class TestEolFetchableForAllConfigs(unittest.TestCase):
+    """Verify that every non-Windows config in temurin.yml can fetch an EOL date from the API."""
+
+    @classmethod
+    def setUpClass(cls):
+        import yaml
+        with open("config/temurin.yml") as f:
+            cls.config = yaml.safe_load(f)
+
+    def test_all_linux_and_alpine_configs_fetch_eol_from_api(self):
+        """Each non-Windows config should resolve a product/cycle and get a valid date from endoflife.date."""
+        missing = []
+        for os_family, configurations in self.config["configurations"].items():
+            if os_family == "windows":
+                continue
+            for cfg in configurations:
+                os_name = cfg["os"]
+                image = cfg["image"]
+                product = OS_TO_PRODUCT.get(os_name)
+                cycle = _extract_cycle(image)
+
+                with self.subTest(image=image):
+                    self.assertIsNotNone(product, f"No endoflife.date product mapping for os={os_name}")
+                    self.assertIsNotNone(cycle, f"Could not extract version cycle from {image}")
+
+                    eol = fetch_eol_date(product, cycle)
+                    if eol is None:
+                        missing.append(f"{image} ({cfg.get('directory', '')})")
+                    else:
+                        self.assertIsInstance(eol, date, f"EOL for {image} is not a date: {eol}")
+
+        self.assertEqual(
+            missing, [],
+            f"Could not fetch EOL date from endoflife.date API for: {', '.join(missing)}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `eol_checker.py` module that fetches EOL dates from the [endoflife.date](https://endoflife.date) API for Ubuntu, Alpine, and RHEL/UBI base images
- Remove hardcoded EOL comments from `config/temurin.yml` — dates are now fetched dynamically
- Add EOL warnings to `generate_dockerfiles.py` and `dockerhub_doc_config_update.py` so they print warnings when a distro is past EOL
- Add weekly GitHub Actions workflow (`check-eol.yml`) that checks for expired distros and creates/updates a cleanup issue with the `eol-cleanup` label
- Add `test_eol_checker.py` with unit tests and an integration test that verifies every non-Windows config can fetch an EOL date from the API
- Update CI workflow to use `unittest discover` for automatic test discovery